### PR TITLE
[Experimental]Use Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+
+jdk:
+  - oraclejdk7
+  - openjdk6
+
+
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#ccm"
+    on_success: change
+    on_failure: always
+    template:
+      - "%{repository} (%{branch}:%{commit} by %{author}): %{message} (%{build_url})" 


### PR DESCRIPTION
Step one: Sign in #

To get started with Travis CI, sign in through GitHub OAuth. Go to Travis CI and follow the Sign In link at the top.

GitHub will ask you to grant read and write access. Travis CI needs write access for setting up service hooks for your repositories when you request it, but it won't touch anything else.
Step two: Activate GitHub Service Hook #

Once you're signed in go to your profile page. You'll see a list of your repositories. Flip the on/off switch for each repository that you want to hook up on Travis CI. Then visit the GitHub service hooks page for that project and paste your GitHub username and Travis token into the settings for the Travis service if it is not already pre-filled.

If your repository belongs to an organization or flipping the switch did not set up the hook, please set it up manually on GitHub. It will take just a couple of minutes.
Step three: Add .travis.yml file to your repository #

In order for Travis to build your project, you need to tell the system a little bit about it. To do so, add .travis.yml to the root of your repository. We will only cover basic .travis.yml options in this guide. The most important one is the language key. It tells Travis what builder to pick. Ruby projects typically use different build tools and practices than Clojure or PHP projects do, so Travis needs to know what to do.
