### PR TITLE
Issue #423: Unneeded consecutive separator lines are displayed when viewing a record with missing information

### DIFF
--- a/resources/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
+++ b/resources/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
@@ -5328,12 +5328,12 @@ table.extradata-list td.bmi_percentile {
 #end
 
 #if ("$!activeFields.contains('age_of_onset')" != 'false')
-  ----
+  #if($doc.display('age_of_onset') != '')----#end
   #__displayIfNotEmpty('age_of_onset')
 #end
 (% class="clear" %)((()))
 #if ("$!activeFields.contains('indication_for_referral')" != 'false')
-  ----
+  #if($xcontext.action == 'edit' || ($doc.display('indication_for_referral') != ''))----#end
   #__displayIfNotEmpty('indication_for_referral')
 #end
 )))##chapter


### PR DESCRIPTION
Fixed
