### PR TITLE
Issue #842: White border displayed on top of the blue "Reported by" band

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
@@ -3415,6 +3415,7 @@ hr {
 .space-data #mainContentArea, .space-data #mainEditArea {
     background-color: #F9F9F9;
     border: 1px solid #FFFFFF;
+    border-top: none;
     box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
     margin: 3em 0;
     padding: 0.5em 10px;


### PR DESCRIPTION
Fix for : White border displayed on top of the blue "Reported by" band (https://github.com/phenotips/phenotips/issues/842)
