### PR TITLE
Issue #843. Re-editing the study form customization reverts to the global form customization.

### DIFF
--- a/resources/ui/src/main/resources/PhenoTips/FormDesigner.xml
+++ b/resources/ui/src/main/resources/PhenoTips/FormDesigner.xml
@@ -762,15 +762,15 @@ document.observe("xwiki:dom:loaded", function(){
   #elseif("$!{selectionOverride}" != '' &amp;&amp; $selectionOverride.size() == 0)
     #set ($tempList = [])
     #foreach($uix in $uixs)
-        #set ($enabled = $uix.getParameters().get("enabled"))
-        #if ("$!{enabled}" == "false" || "$!{enabled}" == "0" || "$!{enabled}" == "no")
-            #set ($enabled = false)
-        #else
-            #set ($enabled = true)
-        #end
-        #if ($enabled)
-            #set($discard = $tempList.add($uix))
-        #end
+      #set ($enabled = $uix.getParameters().get("enabled"))
+      #if ("$!{enabled}" == "false" || "$!{enabled}" == "0" || "$!{enabled}" == "no")
+          #set ($enabled = false)
+      #else
+          #set ($enabled = true)
+      #end
+      #if ($enabled)
+          #set($discard = $tempList.add($uix))
+      #end
     #end
     #set ($uixs = $tempList)
   #end


### PR DESCRIPTION
A slightly hackish solution. Fixes this bug plus another FormDesigner (w/ Studies) issue, which are closley related.
