### PR TITLE
Issue #928: Abnormal measurements don't autoselect phenotypes that are not present in the current mapping.

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
@@ -1731,7 +1731,7 @@ document.observe('xwiki:dom:loaded', function() {
               var categories = '&lt;span class="hidden term-category"&gt;';
               response.term_category.each(function(category){categories += '&lt;input type="hidden" value="' + category + '"&gt;'});
               categories + "&lt;/span&gt;";
-              var data = {'id':id, 'value':response.name, 'categories': categories}
+              var data = {'id':id, 'value':response.name, 'category': categories}
               var title =  response.name;
               suggestWidget.acceptEntry(data, title, title);
               _this._selectMeasurementTerm(findFormElementForPhenotype(id), true);


### PR DESCRIPTION
**Hacked the automatic measurement selections to add new phenotypes though the 'quick-search'.**
