### PR TITLE
Issue #744: "Hide Suggestions" in Quick Phenotype Search is not visible ...

### DIFF
--- a/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
@@ -4453,10 +4453,11 @@ div.suggestItems .hide-button-wrapper {
   border-bottom: 1px dotted;
 }
 div.suggestItems .hide-button {
+  color: $theme.linkColor;
   cursor: pointer;
   font-size: 0.8em;
   font-style: italic;
-  opacity: .4;
+  opacity: 1;
   padding: 0 0.5em;
   margin: 0 4px;
 }


### PR DESCRIPTION
...enough

Fixed by increasing the opacity and changing the color to linkColor.
