### PR TITLE
Issue #1527: Non-standard phenotypes break the OMIM suggestions

### DIFF
--- a/components/diagnosis-suggestion/api/pom.xml
+++ b/components/diagnosis-suggestion/api/pom.xml
@@ -29,7 +29,7 @@
   <name>PhenoTips - Diagnosis Suggestion Java Code</name>
 
   <properties>
-    <coverage.instructionRatio>0.82</coverage.instructionRatio>
+    <coverage.instructionRatio>0.81</coverage.instructionRatio>
   </properties>
 
   <dependencies>

--- a/components/diagnosis-suggestion/api/pom.xml
+++ b/components/diagnosis-suggestion/api/pom.xml
@@ -84,4 +84,28 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>clirr-maven-plugin</artifactId>
+        <configuration>
+          <ignored> 
+            <!-- Remove the following ignores after we release 1.2m2 -->
+            <difference>
+              <className>org/phenotips/diagnosis/DiagnosisService</className>
+              <differenceType>7004</differenceType>
+              <method>java.util.List getDiagnosis(java.util.List, int)</method>
+            </difference>
+            <difference>
+              <className>org/phenotips/diagnosis/script/DiagnosisScriptService</className>
+              <differenceType>7004</differenceType>
+              <method>java.util.List get(java.util.List, int)</method>
+            </difference>
+          </ignored>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/components/diagnosis-suggestion/api/pom.xml
+++ b/components/diagnosis-suggestion/api/pom.xml
@@ -84,28 +84,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>clirr-maven-plugin</artifactId>
-        <configuration>
-          <ignored> 
-            <!-- Remove the following ignores after we release 1.2m2 -->
-            <difference>
-              <className>org/phenotips/diagnosis/DiagnosisService</className>
-              <differenceType>7004</differenceType>
-              <method>java.util.List getDiagnosis(java.util.List, int)</method>
-            </difference>
-            <difference>
-              <className>org/phenotips/diagnosis/script/DiagnosisScriptService</className>
-              <differenceType>7004</differenceType>
-              <method>java.util.List get(java.util.List, int)</method>
-            </difference>
-          </ignored>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/DiagnosisService.java
+++ b/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/DiagnosisService.java
@@ -41,8 +41,9 @@ public interface DiagnosisService
      *
      * @param phenotypes a list of phenotype term IDs observed in the patient; each phenotype is represented as a String
      *            in the format {@code <ontology prefix>:<term id>}, for example {@code HP:0002066}
+     * @param nonstandardPhenotypes a list of non-standard phenotype terms observed in the patient
      * @param limit the maximum number of diagnoses to return; must be a positive number
      * @return a list of suggested diagnoses
      */
-    List<OntologyTerm> getDiagnosis(List<String> phenotypes, int limit);
+    List<OntologyTerm> getDiagnosis(List<String> phenotypes, List<String> nonstandardPhenotypes, int limit);
 }

--- a/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/internal/DefaultDiagnosisService.java
+++ b/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/internal/DefaultDiagnosisService.java
@@ -127,8 +127,10 @@ public class DefaultDiagnosisService implements DiagnosisService, Initializable
     }
 
     @Override
-    public List<OntologyTerm> getDiagnosis(List<String> phenotypes, int limit)
+    public List<OntologyTerm> getDiagnosis(List<String> phenotypes, List<String> nonstandardPhenotypes, int limit)
     {
+        // TODO: use the `nonstandardPhenotypes` argument
+
         Observations o = new Observations();
         o.observations = new boolean[this.boqa.getOntology().getNumberOfTerms()];
         boolean searchIsEmpty = true;

--- a/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/script/DiagnosisScriptService.java
+++ b/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/script/DiagnosisScriptService.java
@@ -51,11 +51,12 @@ public class DiagnosisScriptService implements ScriptService
      *
      * @param phenotypes a list of phenotype term IDs observed in the patient; each phenotype is represented as a String
      *            in the format {@code <ontology prefix>:<term id>}, for example {@code HP:0002066}
+     * @param nonstandardPhenotypes a list of non-standard phenotype terms observed in the patient
      * @param limit the maximum number of diagnoses to return; must be a positive number
      * @return a list of suggested diagnoses
      */
-    public List<OntologyTerm> get(List<String> phenotypes, int limit)
+    public List<OntologyTerm> get(List<String> phenotypes, List<String> nonstandardPhenotypes, int limit)
     {
-        return this.service.getDiagnosis(phenotypes, limit);
+        return this.service.getDiagnosis(phenotypes, nonstandardPhenotypes, limit);
     }
 }

--- a/components/diagnosis-suggestion/api/src/test/java/org/phenotips/diagnosis/internal/DefaultDiagnosisServiceTest.java
+++ b/components/diagnosis-suggestion/api/src/test/java/org/phenotips/diagnosis/internal/DefaultDiagnosisServiceTest.java
@@ -136,8 +136,10 @@ public class DefaultDiagnosisServiceTest
 
         int limit = 3;
         int i = 0;
+        List<String> nonstandardPhenotypeSet = new LinkedList<>();
+        nonstandardPhenotypeSet.add("Non-standard term");
         for (List<String> phenotypeSet : phenotypes) {
-            List<OntologyTerm> diagnoses = diagnosisService.getDiagnosis(phenotypeSet, limit);
+            List<OntologyTerm> diagnoses = diagnosisService.getDiagnosis(phenotypeSet, nonstandardPhenotypeSet, limit);
             List<String> diagnosisIds = new LinkedList<>();
             for (OntologyTerm diagnosis : diagnoses) {
                 diagnosisIds.add(diagnosis.getId());

--- a/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
+++ b/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
@@ -47,12 +47,16 @@
     #if (!$limit || $limit &lt; 0)
       #set ($limit = 20)
     #end
-    #set ($data = [])
+    #set ($symptoms = [])
+    #set ($freeSymptoms = [])
     #foreach ($piece in $!request.getParameterValues('symptom'))
-      #set($discard = $data.add($piece))
+      #set($discard = $symptoms.add($piece))
+    #end
+    #foreach ($piece in $!request.getParameterValues('free_symptom'))
+      #set($discard = $freeSymptoms.add($piece))
     #end
 #if ("$!{request.format}" == 'html')
-#set ($results = $services.diagnosis.get($data, $limit))
+#set ($results = $services.diagnosis.get($symptoms, $freeSymptoms, $limit))
 #if ($results.size() &gt; 0)
 {{html clean="false"  wiki="false"}}##
 &lt;ul&gt;

--- a/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
+++ b/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
@@ -51,9 +51,6 @@
     #foreach ($piece in $!request.getParameterValues('symptom'))
       #set($discard = $data.add($piece))
     #end
-    #foreach ($piece in $!request.getParameterValues('free_symptom'))
-      #set($discard = $data.add($piece))
-    #end
 #if ("$!{request.format}" == 'html')
 #set ($results = $services.diagnosis.get($data, $limit))
 #if ($results.size() &gt; 0)

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
                See http://mojo.codehaus.org/clirr-maven-plugin/examples/ignored-differences.html
           -->
           <ignored>
-            <!-- Remove the following ignores after we release 1.2 -->
+            <!-- Remove the following ignores after we release 1.2M2 -->
             <difference>
               <className>org/phenotips/diagnosis/DiagnosisService</className>
               <differenceType>7004</differenceType>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,18 @@
           -->
           <ignored>
             <!-- Remove the following ignores after we release 1.2 -->
+            <difference>
+              <className>org/phenotips/diagnosis/DiagnosisService</className>
+              <differenceType>7004</differenceType>
+              <method>java.util.List getDiagnosis(java.util.List, int)</method>
+              <justification>The API should accept both ontology terms and non-standard features.</justification>
+            </difference>
+            <difference>
+              <className>org/phenotips/diagnosis/script/DiagnosisScriptService</className>
+              <differenceType>7004</differenceType>
+              <method>java.util.List get(java.util.List, int)</method>
+              <justification>The script service passes both ontology terms and non-standard features to the API.</justification>
+            </difference>
           </ignored>
           <excludes>
             <exclude>**/internal/**</exclude>


### PR DESCRIPTION
Fixed by not searching ontology for free-input terms