### PR TITLE
Issue #1530: Opening the DMG package fails on Mac OS X 10.10 due to miss...

### DIFF
--- a/distribution/dmg/pom.xml
+++ b/distribution/dmg/pom.xml
@@ -42,6 +42,7 @@
     <dmgDir>${bundleName} DMG</dmgDir>
     <bundleDir>${dmgDir}/${bundleName}.app</bundleDir>
     <makeDmgScript>makeDMG.sh</makeDmgScript>
+    <codesignCertCommonName>sickkids-ccm</codesignCertCommonName>
     <!-- Optional properties -->
     <iconFile>application-icon.icns</iconFile>
     <!-- the image in volumeBackgroundFile has to show a right-pointing arrow in the center -->

--- a/distribution/dmg/src/main/app-resources/makeDMG.sh
+++ b/distribution/dmg/src/main/app-resources/makeDMG.sh
@@ -31,6 +31,7 @@ PROP_dmgFile="${project.build.finalName}.dmg"
 PROP_bundleDir="${bundleDir}"
 PROP_includeApplicationsSymlink="${includeApplicationsSymlink}"
 PROP_internetEnable="${internetEnable}"
+PROP_codesignCertCommonName="${codesignCertCommonName}"
 
 [ -n "$PROP_workDir" -a -d "$PROP_workDir" ] ||
   { echo "[ERROR] Invalid work directory \"$PROP_workDir\""; exit 1; }
@@ -70,6 +71,8 @@ else
 fi
 
 SetFile -a B "$PROP_bundleDir" &>/dev/null
+
+codesign -s "$PROP_codesignCertCommonName" "$PROP_bundleDir" &>/dev/null
 
 function createDiskImage {
   local dmgFile dmgFormat


### PR DESCRIPTION
...ing signature

The behaviour is as follows:

When the DMG package is built, an attempt will be made to sign the app bundle, using a certificate with the Common Name matching the value of the ```codesignCertCommonName``` property in the pom.xml (set right now to ```sickkids-ccm```). The certificate is expected to be present in the current user's default Mac OS X keychain. During this process, if the default keychain is locked, *the user will be prompted to unlock it and the build process will wait until it has been unlocked.*

If the certificate is not found, the makeDMG process continues silently and the resulting app bundle simply won't be signed.

Once we have the signing cert, we will simply need to change ```codesignCertCommonName``` to match its name and add it to the local keychain of the building user.