### PR TITLE
Issue #1492: Expand/collapse all should be made more visual

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
@@ -766,12 +766,12 @@ document.observe('xwiki:dom:loaded', function() {
                  var source = event.findElement('.summary-item');
                  var detailsElt = new Element('div', {'class' : 'phenotype-details loading'}).update("$services.localization.render('phenotips.patientSheetCode.termSuggest.loading')");
                  source.insert(detailsElt);
-                 event.findElement().hide();
+                 var addTrigger = event.findElement('.buttonwrapper');
+                 addTrigger.hide();
                  clearTool.__target = detailsElt;
                  editTool.__target = detailsElt;
                  editClearTools.show();
 
-                 var addTrigger = event.findElement();
                  if (addTrigger.disabled) {
                    return;
                  }


### PR DESCRIPTION
Fix issue where “Add details” does not reappear after clicking “Clear details”