### PR TITLE
Issue #1573: Newly added candidate genes don't get the "reject" button

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheet.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheet.xml
@@ -76,6 +76,7 @@ $xwiki.jsfx.use('uicomponents/widgets/validation/scrollValidation.js')##
   #set ($discard = $options.put('propertyValue', "$!{request.propertyValue}"))
   #set ($discard = $options.put('labels', "$!{request.withLabel}"))
   #set ($discard = $options.put('mode', 'edit'))
+  #set ($discard = $options.put('rejectToClass', "$!{request.rejectToClass}"))
   #__extradata_displayLastEntry($request.dataClassName $options)
 #elseif ("$!{request.xaction}" == 'lastmeta')
   #__phenotypeMeta_displayLastEntry()

--- a/components/widgets/ui/src/main/resources/PhenoTips/TabelarDataMacros.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/TabelarDataMacros.xml
@@ -264,7 +264,7 @@ $xwiki.ssx.use('PhenoTips.TabelarDataMacros')##
           }
           newRow.insert(response.responseText);
           newRow.down('a.delete').observe('click', this.ajaxDeleteData.bindAsEventListener(this));
-          newRow.down('a.reject').observe('click', this.ajaxRejectData.bindAsEventListener(this));
+          newRow.down('a.reject') &amp;&amp; newRow.down('a.reject').observe('click', this.ajaxRejectData.bindAsEventListener(this));
           Event.fire(dataTable, 'extradata:added', {'element' : newRow});
           Event.fire(document, 'xwiki:dom:updated', {'elements' : [newRow]});
         }.bind(this),

--- a/components/widgets/ui/src/main/resources/PhenoTips/TabelarDataMacros.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/TabelarDataMacros.xml
@@ -100,7 +100,7 @@ $xwiki.ssx.use('PhenoTips.TabelarDataMacros')##
   #if ($objects.size() &gt; 0)
     #set ($targetObj = $objects.get($mathtool.sub($objects.size(), 1)))
     #set($dataClass = $targetObj.xWikiClass)
-    {{html wiki="true" clean="false"}}#foreach($prop in $dataClass.properties)&lt;td class="${prop.name}#if ($prop.name == $options.propertyName) hidden#end"&gt;#if ("$!{options.labels}" == 'true'){{html clean="false" wiki="false"}}&lt;label &gt;${prop.translatedPrettyName}:&lt;/label&gt;{{/html}}#end$doc.display($prop.getName(), $options.mode, $targetObj)&lt;/td&gt;#end#if ($options.mode == 'edit')&lt;td class="actions"&gt;#__extradata_rejectTool($targetObj '' $options)&lt;/td&gt;&lt;td class="actions"&gt;#__extradata_deleteTool($targetObj '')&lt;/td&gt;#end{{/html}}
+    {{html wiki="true" clean="false"}}#foreach($prop in $dataClass.properties)&lt;td class="${prop.name}#if ($prop.name == $options.propertyName) hidden#end"&gt;#if ("$!{options.labels}" == 'true'){{html clean="false" wiki="false"}}&lt;label &gt;${prop.translatedPrettyName}:&lt;/label&gt;{{/html}}#end$doc.display($prop.getName(), $options.mode, $targetObj)&lt;/td&gt;#end#if ($options.mode == 'edit')#if("$!{options.rejectToClass}" != '')&lt;td class="actions"&gt;#__extradata_rejectTool($targetObj '' $options)&lt;/td&gt;#end&lt;td class="actions"&gt;#__extradata_deleteTool($targetObj '')&lt;/td&gt;#end{{/html}}
   #end
 #end
 {{/velocity}}

--- a/components/widgets/ui/src/main/resources/PhenoTips/TabelarDataMacros.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/TabelarDataMacros.xml
@@ -78,7 +78,7 @@ $xwiki.ssx.use('PhenoTips.TabelarDataMacros')##
 
       #end## foreach object
     #else
-      (% class="extradata-list#if ("$!{options.labels}" == 'true') withLabel#end#if ("$!{options.counter}" == 'true') withCounter#end $!{options.cssClass}" id="extradata-list-${dataClassName}#if("$!{options.propertyName}" != '')-$!{options.propertyValue}#end" %)
+      (% class="extradata-list#if ("$!{options.labels}" == 'true') withLabel#end#if ("$!{options.counter}" == 'true') withCounter#end $!{options.cssClass}" id="extradata-list-${dataClassName}#if("$!{options.propertyName}" != '')-$!{options.propertyValue}#end"#if("$!{options.rejectToClass}" != '') data-reject-to-class="$!{options.rejectToClass}"#end %)
       #if ("$!{options.counter}" == 'true')|=(% class="col-label" %)# #end#foreach($prop in $dataClass.properties)|=(% class="col-label $prop.name#if ($prop.name == $options.propertyName) hidden#end" %)$prop.translatedPrettyName#end#if("$!{options.rejectToClass}" != '')|=(% class="actions" %)#end#if ($options.mode == 'edit')|=(% class="actions" %)
       #else
 
@@ -100,7 +100,7 @@ $xwiki.ssx.use('PhenoTips.TabelarDataMacros')##
   #if ($objects.size() &gt; 0)
     #set ($targetObj = $objects.get($mathtool.sub($objects.size(), 1)))
     #set($dataClass = $targetObj.xWikiClass)
-    {{html wiki="true" clean="false"}}#foreach($prop in $dataClass.properties)&lt;td class="${prop.name}#if ($prop.name == $options.propertyName) hidden#end"&gt;#if ("$!{options.labels}" == 'true'){{html clean="false" wiki="false"}}&lt;label &gt;${prop.translatedPrettyName}:&lt;/label&gt;{{/html}}#end$doc.display($prop.getName(), $options.mode, $targetObj)&lt;/td&gt;#end#if ($options.mode == 'edit')&lt;td class="actions"&gt;#__extradata_deleteTool($targetObj '')&lt;/td&gt;#end{{/html}}
+    {{html wiki="true" clean="false"}}#foreach($prop in $dataClass.properties)&lt;td class="${prop.name}#if ($prop.name == $options.propertyName) hidden#end"&gt;#if ("$!{options.labels}" == 'true'){{html clean="false" wiki="false"}}&lt;label &gt;${prop.translatedPrettyName}:&lt;/label&gt;{{/html}}#end$doc.display($prop.getName(), $options.mode, $targetObj)&lt;/td&gt;#end#if ($options.mode == 'edit')&lt;td class="actions"&gt;#__extradata_rejectTool($targetObj '' $options)&lt;/td&gt;&lt;td class="actions"&gt;#__extradata_deleteTool($targetObj '')&lt;/td&gt;#end{{/html}}
   #end
 #end
 {{/velocity}}
@@ -247,7 +247,8 @@ $xwiki.ssx.use('PhenoTips.TabelarDataMacros')##
       var propertyName = addTrigger.href.replace(/.*&amp;xredirect=.*propertyName=([^&amp;]*).*/, '$1') || '';
       var propertyValue = addTrigger.href.replace(/.*&amp;xredirect=.*propertyValue=([^&amp;]*).*/, '$1') || '';
       var addedDisplaySheet = addTrigger.href.replace(/.*&amp;xredirect=.*addedDisplaySheet=([^&amp;]*).*/, '$1') || '';
-      var url = addTrigger.href.replace(/(&amp;xredirect=[^&amp;]*)/m, '$1' + encodeURIComponent('?xpage=plain&amp;xaction=lastentry&amp;dataClassName=' + classname + '&amp;withLabel=' + dataTable.hasClassName('withLabel') + '&amp;propertyName=' + propertyName + '&amp;propertyValue=' + propertyValue + (addedDisplaySheet ? '&amp;sheet=' + addedDisplaySheet : ''))).replace(/#.*/m, '');
+      var rejectToClass = Element.readAttribute(dataTable, 'data-reject-to-class') || '';
+      var url = addTrigger.href.replace(/(&amp;xredirect=[^&amp;]*)/m, '$1' + encodeURIComponent('?xpage=plain&amp;xaction=lastentry&amp;dataClassName=' + classname + '&amp;withLabel=' + dataTable.hasClassName('withLabel') + '&amp;propertyName=' + propertyName + '&amp;propertyValue=' + propertyValue + (addedDisplaySheet ? '&amp;sheet=' + addedDisplaySheet : '' + '&amp;rejectToClass=' + rejectToClass))).replace(/#.*/m, '');
       new Ajax.Request(url, {
         onCreate : function() {
           addTrigger.disabled = true
@@ -263,6 +264,7 @@ $xwiki.ssx.use('PhenoTips.TabelarDataMacros')##
           }
           newRow.insert(response.responseText);
           newRow.down('a.delete').observe('click', this.ajaxDeleteData.bindAsEventListener(this));
+          newRow.down('a.reject').observe('click', this.ajaxRejectData.bindAsEventListener(this));
           Event.fire(dataTable, 'extradata:added', {'element' : newRow});
           Event.fire(document, 'xwiki:dom:updated', {'elements' : [newRow]});
         }.bind(this),


### PR DESCRIPTION
This PR includes a fix for the bug in PR #1578, where the new reject row would not be filled with the data from the original row. The issue was that ```observe()``` was being invoked on ```undefined``` (returned by ```newRow.down('a.reject')```) and then the function was being aborted, causing the ```extradata:added``` event to not be fired.