### PR TITLE
Issue #1613: Publish XWiki JavaScript event when the value of the specificity widget score on the patient form changes

### DIFF
--- a/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
+++ b/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
@@ -240,11 +240,10 @@
       this.meterDisplay.title = this.levels[Math.round(value)] + " (" + value.toPrecision(3) + "/5)";
       this.meterDisplay.update(new Element('div', {'id' : "specificity-meter-value", "style" : "width: " + Math.round(v * 100) + "%;"}));
       if (oldValue != this._crtValue) {
-        var eventData = { "value": value.toPrecision(3), "title": this.meterDisplay.title };
-        document.fire("phenotype:specificity-meter:change", eventData);
-      }
-     
-    },
+	    var eventData = {"value": this._crtValue, "level": this.levels[Math.round(value)]};
+	    document.fire("phenotips:specificity-meter:change", eventData);
+	  }
+	},
 
     loadingValue : function() {
       this.meterDisplay.update(new Element('div', {'id' : "specificity-meter-value-loading"}).update(new Element('span', {'class' : "fa fa-lg fa-spinner fa-spin"})));

--- a/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
+++ b/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
@@ -234,10 +234,16 @@
     },
 
     showValue : function(v) {
+      var oldValue = this._crtValue;
       this._crtValue = Math.min(1, Math.max(0, isNaN(v) ? 0 : v));
       var value = this._crtValue * 5;
       this.meterDisplay.title = this.levels[Math.round(value)] + " (" + value.toPrecision(3) + "/5)";
       this.meterDisplay.update(new Element('div', {'id' : "specificity-meter-value", "style" : "width: " + Math.round(v * 100) + "%;"}));
+      if (oldValue != this._crtValue) {
+        var eventData = { "value": value.toPrecision(3), "title": this.meterDisplay.title };
+        document.fire("phenotype:specificity-meter:change", eventData);
+      }
+     
     },
 
     loadingValue : function() {


### PR DESCRIPTION
Change in the specificity metric value fires the
phenotype:specificity-meter:change event which data { "value":
[value], "title": [title] }