### PR TITLE
Solr access tests

### DIFF
--- a/components/solr-access-service/api/pom.xml
+++ b/components/solr-access-service/api/pom.xml
@@ -29,7 +29,7 @@
   <name>PhenoTips - Solr Access Service - Java code</name>
   <properties>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <coverage.instructionRatio>0.46</coverage.instructionRatio>
+    <coverage.instructionRatio>0.55</coverage.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/components/solr-access-service/api/pom.xml
+++ b/components/solr-access-service/api/pom.xml
@@ -29,6 +29,7 @@
   <name>PhenoTips - Solr Access Service - Java code</name>
   <properties>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
+    <coverage.instructionRatio>0.46</coverage.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/components/solr-access-service/api/src/main/java/org/phenotips/solr/HPOScriptService.java
+++ b/components/solr-access-service/api/src/main/java/org/phenotips/solr/HPOScriptService.java
@@ -78,12 +78,16 @@ public class HPOScriptService extends AbstractSolrScriptService
             crt = nodes.poll();
             results.add(String.valueOf(crt.get(ID_FIELD_NAME)));
             @SuppressWarnings("unchecked")
-            List<String> parents = (List<String>) crt.get("is_a");
+            Object parents = crt.get("is_a");
             if (parents == null) {
                 continue;
             }
-            for (String pid : parents) {
-                nodes.add(this.get(StringUtils.substringBefore(pid, " ")));
+            if (parents.getClass() == String.class) {
+                nodes.add(this.get(StringUtils.substringBefore((String) parents, " ")));
+            } else {
+                for (String pid : (List<String>) parents) {
+                    nodes.add(this.get(StringUtils.substringBefore(pid, " ")));
+                }
             }
         }
         return results;

--- a/components/solr-access-service/api/src/main/java/org/phenotips/solr/HPOScriptService.java
+++ b/components/solr-access-service/api/src/main/java/org/phenotips/solr/HPOScriptService.java
@@ -25,6 +25,7 @@ import org.xwiki.component.annotation.Component;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -82,12 +83,11 @@ public class HPOScriptService extends AbstractSolrScriptService
             if (parents == null) {
                 continue;
             }
-            if (parents.getClass() == String.class) {
-                nodes.add(this.get(StringUtils.substringBefore((String) parents, " ")));
-            } else {
-                for (String pid : (List<String>) parents) {
-                    nodes.add(this.get(StringUtils.substringBefore(pid, " ")));
-                }
+            if (parents instanceof String) {
+                parents = Collections.singletonList(parents);
+            }
+            for (String pid : (List<String>) parents) {
+                nodes.add(this.get(StringUtils.substringBefore(pid, " ")));
             }
         }
         return results;

--- a/components/solr-access-service/api/src/main/java/org/phenotips/solr/HPOScriptService.java
+++ b/components/solr-access-service/api/src/main/java/org/phenotips/solr/HPOScriptService.java
@@ -66,6 +66,7 @@ public class HPOScriptService extends AbstractSolrScriptService
      * @param id the HPO identifier to search for, in the {@code HP:1234567} format
      * @return the full set of ancestors-or-self IDs, or an empty set if the requested ID was not found in the index
      */
+    @SuppressWarnings("unchecked")
     public Set<String> getAllAncestorsAndSelfIDs(final String id)
     {
         Set<String> results = new HashSet<String>();
@@ -78,15 +79,17 @@ public class HPOScriptService extends AbstractSolrScriptService
         while (!nodes.isEmpty()) {
             crt = nodes.poll();
             results.add(String.valueOf(crt.get(ID_FIELD_NAME)));
-            @SuppressWarnings("unchecked")
-            Object parents = crt.get("is_a");
-            if (parents == null) {
+            Object rawParents = crt.get("is_a");
+            if (rawParents == null) {
                 continue;
             }
-            if (parents instanceof String) {
-                parents = Collections.singletonList(parents);
+            List<String> parents;
+            if (rawParents instanceof String) {
+                parents = Collections.singletonList(String.valueOf(rawParents));
+            } else {
+                parents = (List<String>) rawParents;
             }
-            for (String pid : (List<String>) parents) {
+            for (String pid : parents) {
                 nodes.add(this.get(StringUtils.substringBefore(pid, " ")));
             }
         }

--- a/components/solr-access-service/api/src/test/java/org/phenotips/solr/HPOScriptServiceTest.java
+++ b/components/solr-access-service/api/src/test/java/org/phenotips/solr/HPOScriptServiceTest.java
@@ -1,0 +1,250 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.solr;
+
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.UpdateResponse;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.params.CommonParams;
+import org.junit.Assert;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.params.SolrParams;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.*;
+
+import org.mockito.internal.matchers.CapturingMatcher;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.phenotips.vocabulary.SolrVocabularyResourceManager;
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheException;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollectionOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.*;
+
+
+public class HPOScriptServiceTest
+{
+
+    @Rule
+    public MockitoComponentMockingRule<HPOScriptService> mocker =
+            new MockitoComponentMockingRule<HPOScriptService>(HPOScriptService.class);
+
+    @Mock
+    private Cache<SolrDocument> cache;
+
+    @Mock
+    private SolrClient server;
+
+    @Mock
+    private QueryResponse response;
+
+    private SolrDocumentList solrDocList;
+
+    private int indexReturn;
+
+    private final String fieldNames = "id,name,def,comment,synonym,is_a";
+
+    @Before
+    public void setUp() throws ComponentLookupException, IOException, SolrServerException, CacheException
+    {
+        MockitoAnnotations.initMocks(this);
+        this.solrDocList = null;
+        this.indexReturn = -1;
+
+        SolrVocabularyResourceManager externalServicesAccess =
+                this.mocker.getInstance(SolrVocabularyResourceManager.class);
+        when(externalServicesAccess.getSolrConnection()).thenReturn(this.server);
+
+        CacheManager cacheFactory = this.mocker.getInstance(CacheManager.class);
+        when(cacheFactory.createNewLocalCache((CacheConfiguration) Matchers.any())).thenReturn((Cache) this.cache);
+
+    }
+
+    @Test
+    public void indexAddsDocumentsToServerAndClearsCache() throws IOException, SolrServerException, ComponentLookupException
+    {
+        this.indexMockSolrDocListFromResource();
+
+        verify(this.server).add(anyCollectionOf(SolrInputDocument.class));
+        verify(this.server).commit();
+        verify(this.cache).removeAll();
+        Assert.assertEquals(0, indexReturn);
+    }
+
+    @Test
+    public void getUsesServer() throws ComponentLookupException, IOException, SolrServerException
+    {
+        String id = "HP:0000118";
+
+        when(this.server.query((SolrParams)any())).thenReturn(this.response);
+        this.mocker.getComponentUnderTest().get(id);
+
+        verify(this.server).query(Matchers.argThat(new IsMatchingIDQuery(id)));
+        verify(this.server).query(Matchers.argThat(new IsMatchingAltIDQuery(id)));
+
+    }
+
+    @Test
+    public void getUsesCache() throws ComponentLookupException, IOException, SolrServerException
+    {
+        SolrDocument expectedDoc = mock(SolrDocument.class);
+        SolrDocument unexpectedDoc = mock(SolrDocument.class);
+        String cacheKey = "{id:HP:0000118\n}";
+        when(this.cache.get(anyString())).thenReturn(unexpectedDoc);
+        when(this.cache.get(cacheKey)).thenReturn(expectedDoc);
+        SolrDocument result = this.mocker.getComponentUnderTest().get("HP:0000118");
+        verify(this.server, never()).query((SolrParams)any());
+        Assert.assertSame(expectedDoc, result);
+    }
+
+    @Test
+    public void getCantFindIdReturnsNull() throws ComponentLookupException, IOException, SolrServerException
+    {
+        when(this.server.query((SolrParams)any())).thenReturn(response);
+        when(this.cache.get(anyString())).thenReturn(null);
+        when(this.mocker.getComponentUnderTest().search(anyMap(), 1, 0)).thenReturn(null);
+        SolrDocument result = this.mocker.getComponentUnderTest().get("HP:0000118");
+        verify(this.cache, atLeast(1)).get(anyString());
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void getAllAncestorsAndSelfIDsReturnsAllAncestors() throws ComponentLookupException, IOException, SolrServerException
+    {
+        this.indexMockSolrDocListFromResource();
+        when(this.server.query((SolrParams)any())).thenAnswer(new QueryAnswer());
+
+        Set<String> actualResult = this.mocker.getComponentUnderTest().getAllAncestorsAndSelfIDs("HP:0001507");
+        Set<String> expectedResult = new HashSet<>();
+        expectedResult.add("HP:0001507");
+        expectedResult.add("HP:0000118");
+        expectedResult.add("HP:0000001");
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void clearClearsServerAndCache() throws ComponentLookupException, IOException, SolrServerException
+    {
+        int returnVal = this.mocker.getComponentUnderTest().clear();
+        verify(this.server).deleteByQuery("*:*");
+        verify(this.server).commit();
+        verify(this.cache).removeAll();
+        Assert.assertEquals(0, returnVal);
+    }
+
+    private void indexMockSolrDocListFromResource() throws IOException, SolrServerException, ComponentLookupException
+    {
+        CapturingMatcher<Collection<SolrInputDocument>> allTermsCap = new CapturingMatcher<>();
+        when(this.server.add(Matchers.argThat(allTermsCap))).thenReturn(new UpdateResponse());
+
+        indexReturn = this.mocker.getComponentUnderTest().index(this.getClass().getResource("/hpo-test.obo").toString(), fieldNames);
+
+        Collection<SolrInputDocument> allTerms = allTermsCap.getLastValue();
+        solrDocList = new SolrDocumentList();
+        for(SolrInputDocument i : allTerms){
+            solrDocList.add(ClientUtils.toSolrDocument(i));
+        }
+    }
+
+
+    private class QueryAnswer implements Answer<QueryResponse>{
+
+        @Override
+        public QueryResponse answer(InvocationOnMock invocationOnMock) throws Throwable
+        {
+            SolrParams params = (SolrParams) invocationOnMock.getArguments()[0];
+            if (params == null) {
+                when(response.getResults()).thenReturn(mock(SolrDocumentList.class));
+                return response;
+            }
+            for (SolrDocument item : solrDocList) {
+                String fieldValue = (String)item.getFieldValue("id");
+                fieldValue = fieldValue.replace(":", "\\:");
+                if (params.get(CommonParams.Q).contains(fieldValue)) {
+                    SolrDocumentList matchedItem = new SolrDocumentList();
+                    matchedItem.add(item);
+                    when(response.getResults()).thenReturn(matchedItem);
+                    return response;
+                }
+            }
+            when(response.getResults()).thenReturn(mock(SolrDocumentList.class));
+            return  response;
+        }
+    }
+
+    private class IsMatchingIDQuery extends ArgumentMatcher<SolrParams>{
+
+        private String id;
+
+        public IsMatchingIDQuery(String id){
+            id = id.replace(":", "\\:");
+            this.id = id;
+        }
+
+        @Override
+        public boolean matches(Object argument)
+        {
+            if (argument == null) {
+                return false;
+            }
+            SolrParams params = (SolrParams)argument;
+            return params.get(CommonParams.Q).startsWith("id")
+                    && params.get(CommonParams.Q).contains(id);
+        }
+    }
+
+    private class IsMatchingAltIDQuery extends ArgumentMatcher<SolrParams>{
+
+        private String id;
+
+        public IsMatchingAltIDQuery(String id){
+            id = id.replace(":", "\\:");
+            this.id = id;
+        }
+
+        @Override
+        public boolean matches(Object argument)
+        {
+            if (argument == null) {
+                return false;
+            }
+            SolrParams params = (SolrParams)argument;
+            return params.get(CommonParams.Q).startsWith("alt_id")
+                    && params.get(CommonParams.Q).contains(id);
+        }
+    }
+}

--- a/components/solr-access-service/api/src/test/java/org/phenotips/solr/HPOScriptServiceTest.java
+++ b/components/solr-access-service/api/src/test/java/org/phenotips/solr/HPOScriptServiceTest.java
@@ -113,8 +113,8 @@ public class HPOScriptServiceTest
         when(this.server.query((SolrParams)any())).thenReturn(this.response);
         this.mocker.getComponentUnderTest().get(id);
 
-        verify(this.server).query(Matchers.argThat(new IsMatchingIDQuery(id)));
-        verify(this.server).query(Matchers.argThat(new IsMatchingAltIDQuery(id)));
+        verify(this.server).query(Matchers.argThat(new IsMatchingIDQuery(id, "id")));
+        verify(this.server).query(Matchers.argThat(new IsMatchingIDQuery(id, "alt_id")));
 
     }
 
@@ -175,7 +175,7 @@ public class HPOScriptServiceTest
 
         Collection<SolrInputDocument> allTerms = allTermsCap.getLastValue();
         solrDocList = new SolrDocumentList();
-        for(SolrInputDocument i : allTerms){
+        for (SolrInputDocument i : allTerms) {
             solrDocList.add(ClientUtils.toSolrDocument(i));
         }
     }
@@ -209,10 +209,12 @@ public class HPOScriptServiceTest
     private class IsMatchingIDQuery extends ArgumentMatcher<SolrParams>{
 
         private String id;
+        private String field;
 
-        public IsMatchingIDQuery(String id){
+        public IsMatchingIDQuery(String id, String field){
             id = id.replace(":", "\\:");
             this.id = id;
+            this.field = field;
         }
 
         @Override
@@ -221,30 +223,9 @@ public class HPOScriptServiceTest
             if (argument == null) {
                 return false;
             }
-            SolrParams params = (SolrParams)argument;
-            return params.get(CommonParams.Q).startsWith("id")
-                    && params.get(CommonParams.Q).contains(id);
-        }
-    }
-
-    private class IsMatchingAltIDQuery extends ArgumentMatcher<SolrParams>{
-
-        private String id;
-
-        public IsMatchingAltIDQuery(String id){
-            id = id.replace(":", "\\:");
-            this.id = id;
-        }
-
-        @Override
-        public boolean matches(Object argument)
-        {
-            if (argument == null) {
-                return false;
-            }
-            SolrParams params = (SolrParams)argument;
-            return params.get(CommonParams.Q).startsWith("alt_id")
-                    && params.get(CommonParams.Q).contains(id);
+            String params = ((SolrParams) argument).get(CommonParams.Q);
+            return params.startsWith(field)
+                    && params.contains(id);
         }
     }
 }

--- a/components/solr-access-service/api/src/test/java/org/phenotips/solr/SuggestedPhenotypeTest.java
+++ b/components/solr-access-service/api/src/test/java/org/phenotips/solr/SuggestedPhenotypeTest.java
@@ -21,13 +21,20 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.UUID;
 
+/**
+ *  Tests for the {@link SuggestedPhenotype} class
+ */
 public class SuggestedPhenotypeTest
 {
 
-    private final String testID = "123";
+    private final String testID = "HP:0000118";
     private final String testName = "Test Name";
     private final double testScore = 1.0;
+    private final String otherID = "!!!!!";
+    private final String otherName = "!!!!!";
+    private final double otherScore = -1.0;
     private SuggestedPhenotype testInstance;
 
     @Before
@@ -50,7 +57,7 @@ public class SuggestedPhenotypeTest
         Assert.assertEquals(0, testInstance.compareTo(null));
         Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype(testID, testName, testScore)));
         Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype(testID, testName, testScore)));
-        Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype("!!!!!", "!!!!!", testScore)));
+        Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype(otherID, otherName, testScore)));
         Assert.assertEquals(-1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, (testScore - 0.001))));
         Assert.assertEquals(-1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, -testScore)));
         Assert.assertEquals(-1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, -999999)));
@@ -69,7 +76,28 @@ public class SuggestedPhenotypeTest
         SuggestedPhenotype instanceWithNullID = new SuggestedPhenotype(null, testName, testScore);
         Assert.assertFalse(instanceWithNullID.equals(testInstance));
         Assert.assertFalse(testInstance.equals(instanceWithNullID));
-        Assert.assertFalse(testInstance.equals(new SuggestedPhenotype("!!!!!", testName, testScore)));
-        Assert.assertTrue(testInstance.equals(new SuggestedPhenotype(testID, "!!!!!", testScore)));
+        Assert.assertFalse(testInstance.equals(new SuggestedPhenotype(otherID, testName, testScore)));
+        Assert.assertFalse(testInstance.equals(new SuggestedPhenotype(testID, testName, otherScore)));
+        Assert.assertTrue(testInstance.equals(new SuggestedPhenotype(testID, otherName, testScore)));
+    }
+
+    @Test
+    public void checkHashCodeContractMet() {
+        Assert.assertEquals(testInstance.hashCode(), testInstance.hashCode());
+        Assert.assertEquals(testInstance.hashCode(), new SuggestedPhenotype(testID, testName, testScore).hashCode());
+        Assert.assertEquals(testInstance.hashCode(), new SuggestedPhenotype(testID, otherName, testScore).hashCode());
+
+        double randomScore = Math.random();
+        String randomID = UUID.randomUUID().toString();
+        String randomName = UUID.randomUUID().toString();
+        Assert.assertEquals(new SuggestedPhenotype(randomID, randomName, randomScore).hashCode(),
+            new SuggestedPhenotype(randomID, randomName, randomScore).hashCode());
+        Assert.assertEquals(new SuggestedPhenotype(randomID, randomName, randomScore).hashCode(),
+            new SuggestedPhenotype(randomID, otherID, randomScore).hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        Assert.assertEquals(this.testInstance.toString(), this.testID + '\t' + this.testName + '\t' + this.testScore);
     }
 }

--- a/components/solr-access-service/api/src/test/java/org/phenotips/solr/SuggestedPhenotypeTest.java
+++ b/components/solr-access-service/api/src/test/java/org/phenotips/solr/SuggestedPhenotypeTest.java
@@ -1,0 +1,75 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.solr;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class SuggestedPhenotypeTest
+{
+
+    private final String testID = "123";
+    private final String testName = "Test Name";
+    private final double testScore = 1.0;
+    private SuggestedPhenotype testInstance;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        testInstance = new SuggestedPhenotype(testID, testName, testScore);
+    }
+
+    @Test
+    public void testConstructionAndGetters()
+    {
+        Assert.assertEquals(testID, testInstance.getId());
+        Assert.assertEquals(testName, testInstance.getName());
+        Assert.assertEquals(testScore, testInstance.getScore(), 0);
+    }
+
+    @Test
+    public void testCompareTo()
+    {
+        Assert.assertEquals(0, testInstance.compareTo(null));
+        Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype(testID, testName, testScore)));
+        Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype(testID, testName, testScore)));
+        Assert.assertEquals(0, testInstance.compareTo(new SuggestedPhenotype("!!!!!", "!!!!!", testScore)));
+        Assert.assertEquals(-1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, (testScore - 0.001))));
+        Assert.assertEquals(-1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, -testScore)));
+        Assert.assertEquals(-1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, -999999)));
+        Assert.assertEquals(1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, 1.1)));
+        Assert.assertEquals(1, testInstance.compareTo(new SuggestedPhenotype(testID, testName, 999999)));
+    }
+
+    @Test
+    @SuppressWarnings("null")
+    public void testEquals()
+    {
+        Assert.assertTrue(testInstance.equals(testInstance));
+        Assert.assertTrue(testInstance.equals(new SuggestedPhenotype(testID, testName, testScore)));
+        Assert.assertFalse(testInstance.equals(null));
+        Assert.assertFalse(testInstance.equals(new Object()));
+        SuggestedPhenotype instanceWithNullID = new SuggestedPhenotype(null, testName, testScore);
+        Assert.assertFalse(instanceWithNullID.equals(testInstance));
+        Assert.assertFalse(testInstance.equals(instanceWithNullID));
+        Assert.assertFalse(testInstance.equals(new SuggestedPhenotype("!!!!!", testName, testScore)));
+        Assert.assertTrue(testInstance.equals(new SuggestedPhenotype(testID, "!!!!!", testScore)));
+    }
+}

--- a/components/solr-access-service/api/src/test/resources/hpo-test.obo
+++ b/components/solr-access-service/api/src/test/resources/hpo-test.obo
@@ -1,0 +1,74 @@
+format-version: 1.2
+data-version: releases/2015-04-10
+saved-by: Peter Robinson, Sebastian Koehler, Sandra Doelken, Chris Mungall, Melissa Haendel, Nicole Vasilevsky, Monarch Initiative, et al
+auto-generated-by: OBO-Edit 2.3
+subsetdef: hposlim_core "Core clinical terminology"
+subsetdef: secondary_consequence "Consequence of a disorder in another organ system."
+default-namespace: human_phenotype
+ontology: hp
+owl-axioms: Prefix(owl:=<http://www.w3.org/2002/07/owl#>)\nPrefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)\nPrefix(xml:=<http://www.w3.org/XML/1998/namespace>)\nPrefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)\nPrefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)\n\n\nOntology(\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasOBONamespace> <http://purl.obolibrary.org/obo/HP_0030243> \"\")\nAnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> <http://purl.obolibrary.org/obo/HP_0000040> \"\")\n)
+logical-definition-view-relation: has_part
+
+[Term]
+id: HP:0000001
+name: All
+comment: Root of all terms in the Human Phenotype Ontology.
+
+[Term]
+id: HP:0000118
+name: Phenotypic abnormality
+def: "A phenotypic abnormality." [HPO:probinson]
+comment: This is the root of the phenotypic abnormality subontology of the HPO.
+synonym: "Organ abnormality" EXACT []
+is_a: HP:0000001 ! All
+
+[Term]
+id: HP:0001507
+name: Growth abnormality
+alt_id: HP:0008904
+synonym: "ABNORMAL GROWTH" EXACT []
+is_a: HP:0000118 ! Phenotypic abnormality
+
+[Term]
+id: HP:0000002
+name: Abnormality of body height
+def: "Deviation from the norm of height with respect to that which is expected according to age and gender norms." [HPO:probinson]
+is_a: HP:0001507 ! Growth abnormality
+created_by: peter
+creation_date: 2008-02-27T02:20:00Z
+
+[Term]
+id: HP:0004323
+name: Abnormality of body weight
+alt_id: HP:0010718
+def: "An abnormal increase or decrease of weight or an abnormal distribution of mass in the body." [HPO:probinson]
+synonym: "Abnormality of habitus" RELATED []
+is_a: HP:0001507 ! Growth abnormality
+created_by: peter
+creation_date: 2008-02-27T03:21:00Z
+
+[Term]
+id: HP:0001510
+name: Growth delay
+alt_id: HP:0001434
+alt_id: HP:0001512
+alt_id: HP:0001514
+alt_id: HP:0001517
+alt_id: HP:0001532
+alt_id: HP:0008847
+alt_id: HP:0008870
+alt_id: HP:0008886
+alt_id: HP:0008893
+alt_id: HP:0008926
+def: "A deficiency or slowing down of growth pre- and postnatally." [HPO:probinson]
+comment: Poor or abnormally slow gains in weight or height in a child.
+synonym: "Delayed growth" EXACT []
+synonym: "Growth deficiency" EXACT []
+synonym: "Growth failure" EXACT []
+synonym: "Growth retardation" EXACT []
+synonym: "Poor growth" EXACT []
+synonym: "Retarded growth" EXACT []
+synonym: "VERY POOR GROWTH" RELATED [HPO:skoehler]
+xref: UMLS:C0476243 "Physical retardation"
+xref: UMLS:C0878787 "Growth failure"
+is_a: HP:0001507 ! Growth abnormality


### PR DESCRIPTION
Commit history on this branch is a bit messed up. I accidentally wrote the measurement tests on the master branch, then branched to write these solr test and the change. 

The change to HPOScriptService.java here is due a problem found in testing. When crt.get("is_a") finds only one ancestor, it returns a String not a List<String>