### PR TITLE
Issue #1842: Undo does not work for some changes in pedigree editor. 

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/controller.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/controller.js
@@ -278,7 +278,7 @@ var Controller = Class.create({
                 if (Object.prototype.toString.call(oldValue) === '[object Array]') {
                     oldValue = oldValue.slice(0);
                 } else if (typeof(oldValue) == 'object') {
-                	oldValue = cloneObject(oldValue);
+                    oldValue = cloneObject(oldValue);
                 }
 
                 undoEvent.memo.properties[propertySetFunction] = oldValue;

--- a/components/pedigree/resources/src/main/resources/pedigree/controller.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/controller.js
@@ -272,12 +272,13 @@ var Controller = Class.create({
                             continue;
                     } catch (err) {
                         // fine, one of the objects is in some other format, maybe date picker has changed
-                        // and this code wa snot updated
+                        // and this code was not updated
                     }
                 }
-
                 if (Object.prototype.toString.call(oldValue) === '[object Array]') {
                     oldValue = oldValue.slice(0);
+                } else if (typeof(oldValue) == 'object') {
+                	oldValue = cloneObject(oldValue);
                 }
 
                 undoEvent.memo.properties[propertySetFunction] = oldValue;


### PR DESCRIPTION
Fixed by cloning if updated element is of a type 'object'.