### PR TITLE
Suppress cast warnings in AbstractComplexController

### DIFF
--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
@@ -25,7 +25,7 @@ import org.phenotips.data.VocabularyProperty;
 import org.phenotips.data.internal.AbstractPhenoTipsVocabularyProperty;
 
 import org.xwiki.bridge.DocumentAccessBridge;
-import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.ObjectPropertyReference;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -77,7 +77,8 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
             }
             Map<String, T> result = new LinkedHashMap<String, T>();
             for (String propertyName : getProperties()) {
-                BaseProperty<EntityReference> field = (BaseProperty<EntityReference>) data.getField(propertyName);
+                BaseProperty<ObjectPropertyReference> field =
+                    (BaseProperty<ObjectPropertyReference>) data.getField(propertyName);
                 if (field != null) {
                     Object propertyValue = field.getValue();
                     /* If the controller only works with codes, store the Ontology Instances rather than Strings */

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
@@ -25,6 +25,7 @@ import org.phenotips.data.VocabularyProperty;
 import org.phenotips.data.internal.AbstractPhenoTipsVocabularyProperty;
 
 import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.model.reference.EntityReference;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -65,6 +66,7 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
     private Logger logger;
 
     @Override
+    @SuppressWarnings("unchecked")
     public PatientData<T> load(Patient patient)
     {
         try {
@@ -75,13 +77,12 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
             }
             Map<String, T> result = new LinkedHashMap<String, T>();
             for (String propertyName : getProperties()) {
-                BaseProperty field = (BaseProperty) data.getField(propertyName);
+                BaseProperty<EntityReference> field = (BaseProperty<EntityReference>) data.getField(propertyName);
                 if (field != null) {
                     Object propertyValue = field.getValue();
                     /* If the controller only works with codes, store the Ontology Instances rather than Strings */
                     if (getCodeFields().contains(propertyName) && isCodeFieldsOnly()) {
                         List<VocabularyProperty> propertyValuesList = new LinkedList<>();
-                        @SuppressWarnings("unchecked")
                         List<String> terms = (List<String>) propertyValue;
                         for (String termId : terms) {
                             propertyValuesList.add(new QuickOntologyProperty(termId));
@@ -153,6 +154,7 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
      * @param value the value which possibly needs to be formatted
      * @return the formatted object or the original value
      */
+    @SuppressWarnings("unchecked")
     private Object format(String key, Object value)
     {
         if (value == null) {


### PR DESCRIPTION
Changed `AbstractComplexController` to avoid the following compiler warnings:
```
[WARNING] /phenotips/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java:[78,17] found raw type: com.xpn.xwiki.objects.BaseProperty
  missing type arguments for generic class com.xpn.xwiki.objects.BaseProperty<R>
[WARNING]/phenotips/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java:[91,50] unchecked cast
  required: T
  found:    java.lang.Object
[WARNING] /phenotips/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java:[164,50] unchecked cast
  required: java.util.List<T>
  found:    java.lang.Object
```