### PR TITLE
Changed isCodeFieldsOnly() to check type parameter of AbstractComplexController

### DIFF
--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
@@ -25,8 +25,10 @@ import org.phenotips.data.VocabularyProperty;
 import org.phenotips.data.internal.AbstractPhenoTipsVocabularyProperty;
 
 import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.model.reference.ObjectPropertyReference;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -145,7 +147,9 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
      */
     protected boolean isCodeFieldsOnly()
     {
-        return false;
+        ParameterizedType t = (ParameterizedType) this.getClass().getGenericSuperclass();
+        return new DefaultParameterizedType(null, List.class, VocabularyProperty.class).equals(
+            t.getActualTypeArguments()[0]);
     }
 
     /**

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
@@ -149,7 +149,7 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
     protected boolean isCodeFieldsOnly()
     {
         Type type = this.getClass().getGenericSuperclass();
-        if(! (type instanceof ParameterizedType)) {
+        if (!(type instanceof ParameterizedType)) {
             return false;
         }
         ParameterizedType t = (ParameterizedType) type;

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AbstractComplexController.java
@@ -29,6 +29,7 @@ import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.model.reference.ObjectPropertyReference;
 
 import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -147,7 +148,11 @@ public abstract class AbstractComplexController<T> implements PatientDataControl
      */
     protected boolean isCodeFieldsOnly()
     {
-        ParameterizedType t = (ParameterizedType) this.getClass().getGenericSuperclass();
+        Type type = this.getClass().getGenericSuperclass();
+        if(! (type instanceof ParameterizedType)) {
+            return false;
+        }
+        ParameterizedType t = (ParameterizedType) type;
         return new DefaultParameterizedType(null, List.class, VocabularyProperty.class).equals(
             t.getActualTypeArguments()[0]);
     }

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/PrenatalPhenotypeController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/PrenatalPhenotypeController.java
@@ -76,9 +76,4 @@ public class PrenatalPhenotypeController extends AbstractComplexController<List<
         return this.hpoCodes;
     }
 
-    @Override
-    protected boolean isCodeFieldsOnly()
-    {
-        return true;
-    }
 }


### PR DESCRIPTION
Not sure if this is correct, but it seems as though the only possible case where `isCodeFieldsOnly()` will be overridden to return True is when the value of `< T >` in `AbstractComplexController<T>` is equal to `List<VocabularyProperty>` @sdumitriu Is it possible that a class could extend `AbstractComplexController<List<VocabularyProperty>>` and require that `isCodeFieldsOnly()` return False?