### PR TITLE
PT-825: include phenotype ancestors in patient index

### DIFF
--- a/resources/solr-configuration/src/main/resources/patients/conf/schema.xml
+++ b/resources/solr-configuration/src/main/resources/patients/conf/schema.xml
@@ -62,11 +62,10 @@
     <field name="visibility" type="string" indexed="true" stored="true" required="false" />
     <field name="accessLevel" type="int" indexed="true" stored="true" required="false" />
 
-    <!-- Index all fields ending in "phenotype", only store those that start with "actual_" -->
-    <dynamicField name="actual_*" type="text_ws" indexed="true" stored="true" multiValued="true"/>
-    <!-- We don't use the full "phenotype" in the pattern since Solr applies the longest matching pattern,
-         so we must keep it shorter than "actual_" -->
-    <dynamicField name="*notype" type="text_ws" indexed="true" stored="false" multiValued="true"/>
+    <!-- Index all fields ending in "phenotype", not storing those that start with "extended_" -->
+    <!-- Solr applies the longest matching pattern, so the full "phenotype" suffix is not used -->
+    <dynamicField name="*henotype" type="text_ws" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="extended_*" type="text_ws" indexed="true" stored="false" multiValued="true"/>
 
     <!-- Ignore everyting else -->
     <dynamicField name="*" type="ignored" multiValued="true" />


### PR DESCRIPTION
The actual phenotypes are copied into Solr fields according to their type:
- present features -> `phenotype`
- absent features -> `negative_phenotype`
- present prenatal features -> `prenatal_phenotype`
- absent prenatal features -> `negative_prenatal_phenotype`

The ancestor hierarchy is merged across all types and stored in two fields:
- `extended_phenotype` - all present phenotypes, regardless of type
- `extended_negative_phenotype` - all absent phenotypes, regardless of type

This PR replaces #1886 and #1909.