### PR TITLE
Escape UIX page titles when needed

### DIFF
--- a/components/skin/ui/src/main/resources/PhenoTips/UIXSheet.xml
+++ b/components/skin/ui/src/main/resources/PhenoTips/UIXSheet.xml
@@ -44,7 +44,7 @@
 #set ($ssx = $doc.getObject('XWiki.StyleSheetExtension'))
 {{html wiki=true}}
 ; Title
-: &lt;input type="text" name="title" value="$!doc.title"/&gt;
+: &lt;input type="text" name="title" value="$services.rendering.escape($!doc.title, $xwiki.currentContentSyntaxId)"/&gt;
 ; Description
 : &lt;textarea name="content" rows="20" cols="80"&gt;{{html wiki="false" clean="false"}}$!escapetool.html($doc.content){{/html}}&lt;/textarea&gt;
 #if ($uix)

--- a/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
+++ b/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
@@ -115,7 +115,7 @@
     #set ($uixDoc = $uixDocsMap.get($uix.id))
     #if ($uixDoc)
       #if ("$!{title}" == '')
-        #set ($title = $uixDoc.title)
+        #set ($title = $services.rendering.escape($uixDoc.title, $xwiki.currentContentSyntaxId))
       #end
       #set ($enabled = $uix.getParameters().get("enabled"))
       #if ("$!{enabled}" == "false" || "$!{enabled}" == "0" || "$!{enabled}" == "no")


### PR DESCRIPTION
This pull request fixes two related bugs:

- When creating a new user interface extension, the title of the extension is cut off and displayed as garbage after the "Title" field.

- If no title parameter is specified, the patient form designer falls back to displaying the extension title, but incorrectly converts the double underscores to an underline.

See the screenshots below.

![inline-form-editor](https://cloud.githubusercontent.com/assets/5951993/11201451/a3bbbb6c-8c9b-11e5-92e8-6024b90032b5.png)

![patient-form-designer](https://cloud.githubusercontent.com/assets/5951993/11201454/a73a6626-8c9b-11e5-9a84-523c966839fc.png)