### PR TITLE
Speed up string operations

### DIFF
--- a/components/application-configuration/api/src/main/java/org/phenotips/configuration/internal/global/DefaultRecordSection.java
+++ b/components/application-configuration/api/src/main/java/org/phenotips/configuration/internal/global/DefaultRecordSection.java
@@ -114,7 +114,7 @@ public class DefaultRecordSection implements RecordSection
         StringBuilder result = new StringBuilder(getName());
         result.append(" [");
         result.append(StringUtils.join(getEnabledElements(), ", "));
-        result.append("]");
+        result.append(']');
         return result.toString();
     }
 

--- a/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinFileExtensionPlugin.java
+++ b/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinFileExtensionPlugin.java
@@ -71,7 +71,8 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
     public String getLink(String filename, XWikiContext context)
     {
         boolean forceSkinAction = (Boolean) getParametersForResource(filename, context).get("forceSkinAction");
-        StringBuilder result = new StringBuilder("<link rel='stylesheet' type='text/css' href='");
+        StringBuilder result = new StringBuilder(128);
+        result.append("<link rel='stylesheet' type='text/css' href='");
         result.append(context.getWiki().getSkinFile(filename, forceSkinAction, context));
         result.append("?v=");
         result.append(sanitize(Utils.getComponent(DistributionManager.class)

--- a/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinFileExtensionPlugin.java
+++ b/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinFileExtensionPlugin.java
@@ -73,7 +73,8 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
         boolean forceSkinAction = (Boolean) getParametersForResource(filename, context).get("forceSkinAction");
         StringBuilder result = new StringBuilder("<link rel='stylesheet' type='text/css' href='");
         result.append(context.getWiki().getSkinFile(filename, forceSkinAction, context));
-        result.append("?v=" + sanitize(Utils.getComponent(DistributionManager.class)
+        result.append("?v=");
+        result.append(sanitize(Utils.getComponent(DistributionManager.class)
             .getDistributionExtension().getId().getVersion().getValue()));
         if (forceSkinAction) {
             result.append(parametersAsQueryString(filename, context));

--- a/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPlugin.java
+++ b/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPlugin.java
@@ -87,7 +87,8 @@ public class JsSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
     @Override
     public String getLink(String documentName, XWikiContext context)
     {
-        StringBuilder result = new StringBuilder("<script type='text/javascript' src='");
+        StringBuilder result = new StringBuilder(128);
+        result.append("<script type='text/javascript' src='");
         result.append(context.getWiki().getURL(documentName, PLUGIN_NAME,
             "language=" + sanitize(context.getLanguage()) + "&amp;hash=" + getHash(documentName, context)
                 + parametersAsQueryString(documentName, context), context));

--- a/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinFileExtensionPlugin.java
+++ b/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinFileExtensionPlugin.java
@@ -82,7 +82,8 @@ public class JsSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
         boolean forceSkinAction = BooleanUtils.toBoolean((Boolean) getParameter("forceSkinAction", filename, context));
         StringBuilder result = new StringBuilder("<script type='text/javascript' src='");
         result.append(context.getWiki().getSkinFile(filename, forceSkinAction, context));
-        result.append("?v=" + sanitize(Utils.getComponent(DistributionManager.class)
+        result.append("?v=");
+        result.append(sanitize(Utils.getComponent(DistributionManager.class)
             .getDistributionExtension().getId().getVersion().getValue()));
         if (forceSkinAction) {
             result.append(parametersAsQueryString(filename, context));

--- a/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinFileExtensionPlugin.java
+++ b/components/base-war/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinFileExtensionPlugin.java
@@ -80,7 +80,8 @@ public class JsSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
     public String getLink(String filename, XWikiContext context)
     {
         boolean forceSkinAction = BooleanUtils.toBoolean((Boolean) getParameter("forceSkinAction", filename, context));
-        StringBuilder result = new StringBuilder("<script type='text/javascript' src='");
+        StringBuilder result = new StringBuilder(128);
+        result.append("<script type='text/javascript' src='");
         result.append(context.getWiki().getSkinFile(filename, forceSkinAction, context));
         result.append("?v=");
         result.append(sanitize(Utils.getComponent(DistributionManager.class)

--- a/components/export/api/src/main/java/org/phenotips/export/internal/ConversionHelpers.java
+++ b/components/export/api/src/main/java/org/phenotips/export/internal/ConversionHelpers.java
@@ -360,7 +360,7 @@ public class ConversionHelpers
             foundBreakIndex = chunkEndIndex >= 0;
             chunkEndIndex += period.length();
         } else {
-            chunkEndIndex = chunkTail.lastIndexOf(" ");
+            chunkEndIndex = chunkTail.lastIndexOf(' ');
             foundBreakIndex = chunkEndIndex >= 0;
             chunkEndIndex += 1;
         }

--- a/components/ncbieutils-services/api/src/main/java/org/phenotips/ncbieutils/internal/AbstractSpecializedNCBIEUtilsAccessService.java
+++ b/components/ncbieutils-services/api/src/main/java/org/phenotips/ncbieutils/internal/AbstractSpecializedNCBIEUtilsAccessService.java
@@ -393,7 +393,7 @@ public abstract class AbstractSpecializedNCBIEUtilsAccessService implements NCBI
         if (list.size() > 0) {
             StringBuilder listBuilder = new StringBuilder();
             for (String item : list) {
-                listBuilder.append(",").append(item);
+                listBuilder.append(',').append(item);
             }
             result = listBuilder.substring(1);
         }

--- a/components/patient-tools/src/main/java/org/phenotips/tools/PropertyDisplayer.java
+++ b/components/patient-tools/src/main/java/org/phenotips/tools/PropertyDisplayer.java
@@ -134,7 +134,7 @@ public class PropertyDisplayer
 
     public String display()
     {
-        StringBuilder str = new StringBuilder();
+        StringBuilder str = new StringBuilder(128);
         for (FormSection section : this.sections) {
             str.append(section.display(this.data.getMode(), this.fieldNames));
         }

--- a/components/solr-access-service/api/src/main/java/org/phenotips/solr/AbstractSolrScriptService.java
+++ b/components/solr-access-service/api/src/main/java/org/phenotips/solr/AbstractSolrScriptService.java
@@ -388,7 +388,7 @@ public abstract class AbstractSolrScriptService implements ScriptService, Initia
                 value.replaceAll("[^a-zA-Z0-9 :]", " ").replace(FIELD_VALUE_SEPARATOR, "\\" + FIELD_VALUE_SEPARATOR)
                     .trim().split("\\s+");
             for (String val : pieces) {
-                query.append(field.getKey()).append(FIELD_VALUE_SEPARATOR).append(val).append(" ");
+                query.append(field.getKey()).append(FIELD_VALUE_SEPARATOR).append(val).append(' ');
             }
         }
         return getSolrQuery(query.toString().trim(), sort, rows, start);

--- a/components/users/api/src/main/java/org/phenotips/groups/internal/DefaultGroupManager.java
+++ b/components/users/api/src/main/java/org/phenotips/groups/internal/DefaultGroupManager.java
@@ -97,11 +97,11 @@ public class DefaultGroupManager implements GroupManager
                 StringBuilder qs = new StringBuilder("from doc.object(XWiki.XWikiGroups) grp where grp.member in (");
                 for (int i = 0; i < nestedGroups.size(); ++i) {
                     if (i > 0) {
-                        qs.append(",");
+                        qs.append(',');
                     }
-                    qs.append("?").append(i + 1);
+                    qs.append('?').append(i + 1);
                 }
-                qs.append(")");
+                qs.append(')');
                 q = this.qm.createQuery(qs.toString(), Query.XWQL);
                 for (int i = 0; i < nestedGroups.size(); ++i) {
                     String formalGroupName =

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractSolrVocabulary.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractSolrVocabulary.java
@@ -280,7 +280,7 @@ public abstract class AbstractSolrVocabulary implements Vocabulary, Initializabl
             if (Collection.class.isInstance(field.getValue()) && ((Collection<?>) field.getValue()).isEmpty()) {
                 continue;
             }
-            query.append("+");
+            query.append('+');
             query.append(ClientUtils.escapeQueryChars(field.getKey()));
             query.append(":(");
             if (Collection.class.isInstance(field.getValue())) {

--- a/components/vocabularies/omim/api/src/main/java/org/phenotips/vocabulary/internal/solr/OmimSourceParser.java
+++ b/components/vocabularies/omim/api/src/main/java/org/phenotips/vocabulary/internal/solr/OmimSourceParser.java
@@ -159,7 +159,7 @@ public class OmimSourceParser
                 fieldValue.setLength(0);
                 fieldName = line.substring(FIELD_MARKER.length());
             } else {
-                fieldValue.append(line.trim()).append(" ");
+                fieldValue.append(line.trim()).append(' ');
             }
         }
 


### PR DESCRIPTION
This patch set makes PhenoTips use best practices when dealing with strings, as identified by `pmd -d . -R java-strings`:

http://pmd.sourceforge.net/pmd-5.2.0/pmd-java/rules/java/strings.html#InefficientStringBuffering

http://pmd.sourceforge.net/pmd-5.2.0/pmd-java/rules/java/strings.html#InsufficientStringBufferDeclaration

http://pmd.sourceforge.net/pmd-5.2.0/pmd-java/rules/java/strings.html#UseIndexOfChar

http://pmd.sourceforge.net/pmd-5.2.0/pmd-java/rules/java/strings.html#AppendCharacterWithChar