### PR TITLE
Prefer "true" and "false" to calling Boolean.toString with a constant

### DIFF
--- a/components/solr-access-service/api/src/main/java/org/phenotips/solr/AbstractSolrScriptService.java
+++ b/components/solr-access-service/api/src/main/java/org/phenotips/solr/AbstractSolrScriptService.java
@@ -429,8 +429,8 @@ public abstract class AbstractSolrScriptService implements ScriptService, Initia
         if (StringUtils.isNotBlank(sort)) {
             result.put(CommonParams.SORT, sort);
         }
-        result.put("spellcheck", Boolean.toString(true));
-        result.put(SpellingParams.SPELLCHECK_COLLATE, Boolean.toString(true));
+        result.put("spellcheck", "true");
+        result.put(SpellingParams.SPELLCHECK_COLLATE, "true");
         return result;
     }
 

--- a/components/solr-access-service/api/src/main/java/org/phenotips/solr/OmimScriptService.java
+++ b/components/solr-access-service/api/src/main/java/org/phenotips/solr/OmimScriptService.java
@@ -159,8 +159,8 @@ public class OmimScriptService extends AbstractSolrScriptService
         params.put(CommonParams.Q, q.replaceAll("HP:", "HP\\\\:"));
         params.put(CommonParams.ROWS, "100");
         params.put(CommonParams.START, "0");
-        params.put(CommonParams.DEBUG_QUERY, Boolean.toString(true));
-        params.put(CommonParams.EXPLAIN_STRUCT, Boolean.toString(true));
+        params.put(CommonParams.DEBUG_QUERY, "true");
+        params.put(CommonParams.EXPLAIN_STRUCT, "true");
 
         return new MapSolrParams(params);
     }

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/SolrQueryUtils.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/SolrQueryUtils.java
@@ -107,8 +107,8 @@ public final class SolrQueryUtils
             }
         }
         if (newParams.get(SPELLCHECK) == null) {
-            newParams.set(SPELLCHECK, Boolean.toString(true));
-            newParams.set(SpellingParams.SPELLCHECK_COLLATE, Boolean.toString(true));
+            newParams.set(SPELLCHECK, "true");
+            newParams.set(SpellingParams.SPELLCHECK_COLLATE, "true");
         }
         return newParams;
     }

--- a/components/vocabularies/hgnc/api/src/main/java/org/phenotips/vocabulary/internal/GeneNomenclature.java
+++ b/components/vocabularies/hgnc/api/src/main/java/org/phenotips/vocabulary/internal/GeneNomenclature.java
@@ -90,7 +90,7 @@ public class GeneNomenclature extends AbstractCSVSolrVocabulary
 
     static {
         Map<String, String> options = new HashMap<>();
-        options.put("lowercaseOperators", Boolean.toString(false));
+        options.put("lowercaseOperators", "false");
         options.put("defType", "edismax");
         COMMON_SEARCH_OPTIONS = Collections.unmodifiableMap(options);
 
@@ -109,20 +109,20 @@ public class GeneNomenclature extends AbstractCSVSolrVocabulary
 
         options = new HashMap<>();
         options.putAll(COMMON_SEARCH_OPTIONS);
-        options.put(spellcheck, Boolean.toString(false));
+        options.put(spellcheck, "false");
         options.put(DisMaxParams.QF, "symbol^50 symbolStub^25 alt_id^20 alt_idStub^10");
         IDENTIFIER_SEARCH_OPTIONS = Collections.unmodifiableMap(options);
 
         options = new HashMap<>();
         options.putAll(COMMON_SEARCH_OPTIONS);
-        options.put(spellcheck, Boolean.toString(false));
+        options.put(spellcheck, "false");
         options.putAll(DISMAX_SEARCH_OPTIONS);
         TEXT_SEARCH_OPTIONS = Collections.unmodifiableMap(options);
 
         options = new HashMap<>();
         options.putAll(COMMON_SEARCH_OPTIONS);
-        options.put(spellcheck, Boolean.toString(true));
-        options.put(SpellingParams.SPELLCHECK_COLLATE, Boolean.toString(true));
+        options.put(spellcheck, "true");
+        options.put(SpellingParams.SPELLCHECK_COLLATE, "true");
         options.put(SpellingParams.SPELLCHECK_COUNT, "100");
         options.put(SpellingParams.SPELLCHECK_MAX_COLLATION_TRIES, "3");
         options.putAll(DISMAX_SEARCH_OPTIONS);

--- a/components/vocabularies/hpo/api/src/main/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntology.java
+++ b/components/vocabularies/hpo/api/src/main/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntology.java
@@ -120,11 +120,11 @@ public class HumanPhenotypeOntology extends AbstractOBOSolrVocabulary
     private Map<String, String> getStaticSolrParams()
     {
         Map<String, String> params = new HashMap<>();
-        params.put("spellcheck", Boolean.toString(true));
-        params.put(SpellingParams.SPELLCHECK_COLLATE, Boolean.toString(true));
+        params.put("spellcheck", "true");
+        params.put(SpellingParams.SPELLCHECK_COLLATE, "true");
         params.put(SpellingParams.SPELLCHECK_COUNT, "100");
         params.put(SpellingParams.SPELLCHECK_MAX_COLLATION_TRIES, "3");
-        params.put("lowercaseOperators", Boolean.toString(false));
+        params.put("lowercaseOperators", "false");
         params.put("defType", "edismax");
         return params;
     }

--- a/components/vocabularies/omim/api/src/main/java/org/phenotips/vocabulary/internal/solr/MendelianInheritanceInMan.java
+++ b/components/vocabularies/omim/api/src/main/java/org/phenotips/vocabulary/internal/solr/MendelianInheritanceInMan.java
@@ -134,11 +134,11 @@ public class MendelianInheritanceInMan extends AbstractSolrVocabulary
     private Map<String, String> getStaticSolrParams()
     {
         Map<String, String> params = new HashMap<>();
-        params.put("spellcheck", Boolean.toString(true));
-        params.put(SpellingParams.SPELLCHECK_COLLATE, Boolean.toString(true));
+        params.put("spellcheck", "true");
+        params.put(SpellingParams.SPELLCHECK_COLLATE, "true");
         params.put(SpellingParams.SPELLCHECK_COUNT, "100");
         params.put(SpellingParams.SPELLCHECK_MAX_COLLATION_TRIES, "3");
-        params.put("lowercaseOperators", Boolean.toString(false));
+        params.put("lowercaseOperators", "false");
         params.put("defType", "edismax");
         return params;
     }


### PR DESCRIPTION
This is mainly just to simplify the code base, although it may also offer a slight performance improvement.