### PR TITLE
Return the patient ID after creating a new patient via the REST API

### DIFF
--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientsResourceImpl.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientsResourceImpl.java
@@ -104,8 +104,8 @@ public class DefaultPatientsResourceImpl extends XWikiResource implements Patien
             Patient patient = this.repository.createNewPatient();
             patient.updateFromJSON(jsonInput);
 
-            URI targetURI =
-                UriBuilder.fromUri(this.uriInfo.getBaseUri()).path(PatientsResource.class).build(patient.getId());
+            UriBuilder targetUriBuilder = UriBuilder.fromUri(this.uriInfo.getBaseUri());
+            URI targetURI = targetUriBuilder.path(PatientsResource.class).path(patient.getId()).build();
             ResponseBuilder response = Response.created(targetURI);
             return response.build();
         } catch (Exception ex) {


### PR DESCRIPTION
The Location header in the HTTP response is always <site>/rest/patients. [The PhenoTips REST documentation](https://phenotips.org/DevGuide/RESTfulAPI#add) says that it's actually supposed to contain a reference to the newly created patient, e.g. /rest/patients/P000123. The REST client does not have a good way to get the new patient ID otherwise.

[UriBuilder.build](https://docs.oracle.com/javaee/7/api/javax/ws/rs/core/UriBuilder.html#build-java.lang.Object...-) is for substituting template parameters, which we don't have. [UriBuilder.path](https://docs.oracle.com/javaee/7/api/javax/ws/rs/core/UriBuilder.html#path-java.lang.String-) is what we want to simply append a slash and a string.