### PR TITLE
PT-2304: Import functionality is broken in pedigree editor

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/model/import.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/model/import.js
@@ -900,7 +900,7 @@ define([
 
            // if there are no children, create a placeholder child
            if (newG.getOutEdges(chhubID).length == 0) {
-               var placeholderID = newG._addVertex(null, TYPE.PERSON, {"gender": "U", "placeholder":true}, newG.defaultPersonNodeWidth );
+               var placeholderID = newG._addVertex(null, BaseGraph.TYPE.PERSON, {"gender": "U", "placeholder":true}, newG.defaultPersonNodeWidth );
                newG.addEdge( chhubID, placeholderID, defaultEdgeWeight );
            }
 
@@ -1403,8 +1403,8 @@ define([
                 if (this.relationships[partnerID1] === undefined) this.relationships[partnerID1] = {};
                 if (this.relationships[partnerID2] === undefined) this.relationships[partnerID2] = {};
 
-                var relID   = this.newG._addVertex( null, TYPE.RELATIONSHIP, {}, this.newG.defaultNonPersonNodeWidth );
-                var chhubID = this.newG._addVertex( null, TYPE.CHILDHUB,     {}, this.newG.defaultNonPersonNodeWidth );
+                var relID   = this.newG._addVertex( null, BaseGraph.TYPE.RELATIONSHIP, {}, this.newG.defaultNonPersonNodeWidth );
+                var chhubID = this.newG._addVertex( null, BaseGraph.TYPE.CHILDHUB,     {}, this.newG.defaultNonPersonNodeWidth );
 
                 this.newG.addEdge( relID,    chhubID, this.defaultEdgeWeight );
                 this.newG.addEdge( partnerID1, relID,   this.defaultEdgeWeight );


### PR DESCRIPTION
Somehow BaseGraph used to be imported into the current scope. My guess is that when the build order changed, BaseGraph could no longer be accessed from import.js without qualification. All but three references to BaseGraph.TYPE in import.js were already qualified, so this change also improves the file's internal consistency.