### PR TITLE
Ping back number of users and cases from all installed PT instances

### DIFF
--- a/components/base-war/pom.xml
+++ b/components/base-war/pom.xml
@@ -244,7 +244,7 @@ extension.repositories=maven-central:maven:https://nexus.phenotips.org/nexus/con
 extension.repositories=maven-phenotips:maven:https://nexus.phenotips.org/nexus/content/repositories/releases/
 extension.repositories=phenotips.org:xwiki:https://phenotips.org/rest/
 rendering.transformations=macro
-activeinstalls.pingURL=http://localhost:9200
+activeinstalls.pingURL=http://stats.phenotips.org
 activeinstalls.ipFetchURL=https://phenotips.org/get/Stats/Id
                 </xwikiPropertiesAdditionalProperties>
               </properties>

--- a/components/base-war/pom.xml
+++ b/components/base-war/pom.xml
@@ -245,6 +245,7 @@ extension.repositories=maven-phenotips:maven:https://nexus.phenotips.org/nexus/c
 extension.repositories=phenotips.org:xwiki:https://phenotips.org/rest/
 rendering.transformations=macro
 activeinstalls.pingURL=http://localhost:9200
+activeinstalls.ipFetchURL=https://phenotips.org/get/Stats/Id
                 </xwikiPropertiesAdditionalProperties>
               </properties>
             </configuration>

--- a/components/base-war/pom.xml
+++ b/components/base-war/pom.xml
@@ -196,6 +196,7 @@
                 <xwikiDbDialect>org.hibernate.dialect.HSQLDialect</xwikiDbDialect>
                 <xwikiDbHbmXwiki>xwiki.hbm.xml</xwikiDbHbmXwiki>
                 <xwikiDbHbmFeeds>feeds.hbm.xml</xwikiDbHbmFeeds>
+                <xwikiDbHbmCommonExtraMappings>instance.hbm.xml</xwikiDbHbmCommonExtraMappings>
                 <xwikiCfgPlugins>\
   com.xpn.xwiki.monitor.api.MonitorPlugin,\
   com.xpn.xwiki.plugin.skinx.JsSkinExtensionPlugin,\
@@ -243,6 +244,7 @@ extension.repositories=maven-central:maven:https://nexus.phenotips.org/nexus/con
 extension.repositories=maven-phenotips:maven:https://nexus.phenotips.org/nexus/content/repositories/releases/
 extension.repositories=phenotips.org:xwiki:https://phenotips.org/rest/
 rendering.transformations=macro
+activeinstalls.pingURL=http://localhost:9200
                 </xwikiPropertiesAdditionalProperties>
               </properties>
             </configuration>

--- a/distribution/war/pom.xml
+++ b/distribution/war/pom.xml
@@ -743,6 +743,16 @@
       <artifactId>phenotips-proxy-authentication</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pingback-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pingback-client-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Add dependencies on the XAR distributions so that we transitively include all JAR dependencies in the generated WAR -->
     <dependency>


### PR DESCRIPTION
This depends on https://github.com/phenotips/pingback and a running instance of ElasticSearch, the configuration for which is provided in pingback repo.