### PR TITLE
Use bold and color, not all caps, for headers in the patient form editor

### DIFF
--- a/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
+++ b/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
@@ -1013,8 +1013,8 @@ document.observe("xwiki:dom:loaded", function(){
   margin: 10px 10px 25px;
 }
 .designer-panel .new-section .section-title{
-  color $theme.titleColor;
-  text-transform: uppercase;
+  color: $theme.titleColor;
+  font-weight: bold;
   padding-left: 16px;
   background: transparent url("$xwiki.getSkinFile('icons/silk/bullet_add.png')") left center no-repeat;
 }
@@ -1090,8 +1090,8 @@ document.observe("xwiki:dom:loaded", function(){
 }
 
 .section-maquette .section-title {
-  color $theme.titleColor;
-  text-transform: uppercase;
+  color: $theme.titleColor;
+  font-weight: bold;
 }
 .section-maquette .section-title * {
   margin: 0 !important;


### PR DESCRIPTION
Currently, the patient form editor displays headings in all caps, whereas the patient form itself does not. This makes it hard to see from the form editor how the form will actually be displayed.

I've put together a simple fix for this problem that displays the headings in bold and color instead of all caps:

**- Before -**
![before](https://cloud.githubusercontent.com/assets/5951993/12928045/9b2927f8-cf28-11e5-9ff2-317237ea7c3b.png)

**- After -**
![after](https://cloud.githubusercontent.com/assets/5951993/12928048/9f481402-cf28-11e5-9622-e0f74e8e2d2d.png)