### PR TITLE
Use default cursors for headers and the change-study button

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetCode.xml
@@ -3900,7 +3900,6 @@ h1, h2, h3, h4 {
 }
 .chapter &gt; h2 {
   border-bottom: 1px solid $theme.titleColor;
-  cursor: default;
   font-family: Georgia,serif;
   font-size: 1.5em;
   margin: -1.5em -10px 0;

--- a/components/studies/ui/src/main/resources/PhenoTips/StudyBindingClass.xml
+++ b/components/studies/ui/src/main/resources/PhenoTips/StudyBindingClass.xml
@@ -551,7 +551,6 @@
   float: left;
 }
 .study-assignment-config a.button {
-  cursor: text;
   font-size: 1em;
   font-weight: normal;
   text-transform: none;


### PR DESCRIPTION
Currently, the mouse cursor set on the change-study button makes it look like it is not clickable, and the cursor set on patient data headings makes it look like they are clickable. These two commits change the cursors back to the defaults that web users expect.