### PR TITLE
Fix XHTML syntax errors

### DIFF
--- a/components/studies/ui/src/main/resources/PhenoTips/StudyBindingClass.xml
+++ b/components/studies/ui/src/main/resources/PhenoTips/StudyBindingClass.xml
@@ -701,7 +701,7 @@ $xwiki.ssx.use($className)##
     #end
     #set($displayedValue = "(% class='buttonwrapper' %)[[{{icon name='copy' /}} ${configTitle}&gt;&gt;${value}||rel='__blank' class='button secondary']]")
   #end
-  #set ($faction = $doc.getURL('save', "form_token=${services.csrf.token}&amp;objectPolicy=updateOrCreate&amp;xredirect=$escapetool.url($doc.getURL($xcontext.action))"))
+  #set ($faction = $doc.getURL('save', "form_token=${services.csrf.token}&amp;amp;objectPolicy=updateOrCreate&amp;amp;xredirect=$escapetool.url($doc.getURL($xcontext.action))"))
 (% class="study-assignment-config" %)(((Study: $displayedValue (% class="buttonwrapper" %)[[ {{icon name="edit" title="$services.localization.render('phenotips.studyBindingClass.changeStudyButton.title')" /}} {{html clean=false}}&lt;input type="hidden" name="faction" value="$faction"/&gt;{{/html}}&gt;&gt;path:$doc.getURL('get', "sheet=$!{sheetName}&amp;faction=$!{escapetool.url($faction)}")||class="button" rel="__blank" id="study-assignment-config" class="$xcontext.action"]])))
 #end
 {{/velocity}}</content>

--- a/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
+++ b/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
@@ -387,7 +387,7 @@ $xwiki.ssfx.use('icons/font-awesome/css/font-awesome.min.css')
   &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}"/&gt;
   &lt;input type="hidden" name="create_extension" value="1"/&gt;
   &lt;input type="hidden" name="xredirect" value="$doc.getURL('get', 'showsection=')"/&gt;
-  &lt;input type="text" name="extension_id" value="" placeholder="$services.localization.render('phenotips.formDesigner.sectionID.placeholder')" title="$services.localization.render('phenotips.formDesigner.sectionID.title')" size="32"/&gt;
+  &lt;input type="text" name="extension_id" value="" placeholder="$escapetool.xml($services.localization.render('phenotips.formDesigner.sectionID.placeholder'))" title="$services.localization.render('phenotips.formDesigner.sectionID.title')" size="32"/&gt;
   &lt;input type="text" name="extension_name" value="" placeholder="$services.localization.render('phenotips.formDesigner.sectionTitle.placeholder')" size="32"/&gt;
   &lt;input class="button" type="button" name="create_extension" value="$services.localization.render('phenotips.formDesigner.createButton')"/&gt;
 &lt;/div&gt;&lt;/form&gt;{{/html}}

--- a/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
+++ b/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
@@ -381,7 +381,7 @@ $xwiki.ssfx.use('icons/font-awesome/css/font-awesome.min.css')
 ## SHOW SECTION ADDITION FORM
 ## =====================================================================
 #if ($globalConfig)
-{{html clean=false wiki=false}}&lt;form action="$formAction" method="post" class="xformInline" id="create-section-form"&gt;
+{{html clean=false wiki=false}}&lt;form action="$escapetool.xml($formAction)" method="post" class="xformInline" id="create-section-form"&gt;
 &lt;h2&gt;Add a form section&lt;/h2&gt;
 &lt;div&gt;
   &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}"/&gt;
@@ -400,7 +400,7 @@ $xwiki.ssfx.use('icons/font-awesome/css/font-awesome.min.css')
 ## ----------------------------------------------------------------------
 ## Display the configuration form if the user has permissions
 ## ----------------------------------------------------------------------
-{{html clean=false wiki=false}}&lt;form action="$formAction" method="post"&gt;{{/html}}
+{{html clean=false wiki=false}}&lt;form action="$escapetool.xml($formAction)" method="post"&gt;{{/html}}
 (% id="patient-form-designer" #if ($globalConfig) class="global" #end%)(((
 (% class="designer-panel sections" %)(((
 #_formDesigner__displaySections()

--- a/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
+++ b/components/vocabularies/hpo/ui/src/main/resources/PhenoTips/FormDesigner.xml
@@ -298,7 +298,7 @@ $xwiki.ssfx.use('icons/font-awesome/css/font-awesome.min.css')
 #macro(_formDesigner__displayExtensionTools $extension $tools)
 {{html wiki=false clean=false}}&lt;div class="extension-tools"&gt;
 #if ($globalConfig)
-#if ($tools.required)&lt;label class="extension-tool flag" title="$services.localization.render('phenotips.formDesigner.requiredExtension')"&gt;&lt;i class="fa fa-asterisk"&gt;&lt;/i&gt;&lt;input type="checkbox" class="uix-required" name="${prefix}${extension.type}s_${extension.id}_required" value="true" #if ($extension.required) checked="true" #end/&gt;&lt;/label&gt;#end
+#if ($tools.required)&lt;label class="extension-tool flag" title="$services.localization.render('phenotips.formDesigner.requiredExtension')"&gt;&lt;i class="fa fa-asterisk"&gt;&lt;/i&gt;&lt;input type="checkbox" class="uix-required" name="${prefix}${extension.type}s_${extension.id}_required" value="true" #if ($extension.required) checked="checked" #end/&gt;&lt;/label&gt;#end
 #if ($tools.edit)#_formDesigner__displayExtensionTool('edit' 'pencil' "$services.localization.render('phenotips.formDesigner.editExtension')" $extension.doc.getURL('edit', 'editor=object') 'target="_blank"')#end
 #if ($tools.delete)#_formDesigner__displayExtensionTool('delete' 'times' "$services.localization.render('phenotips.formDesigner.deleteExtension')" $extension.doc.getURL('delete') 'target="_blank"')#end
 #end
@@ -311,7 +311,7 @@ $xwiki.ssfx.use('icons/font-awesome/css/font-awesome.min.css')
 ## ----------------------------------------------------------------------
 #macro(_formDesigner__displayExtensionInputs $extension $fieldName)##
 {{html wiki=false clean=false}}
-&lt;input type="checkbox" class="uix-toggle"   name="$fieldName" value="${extension.id}" #if ($extension.enabled) checked="true" #end/&gt;
+&lt;input type="checkbox" class="uix-toggle"   name="$fieldName" value="${extension.id}" #if ($extension.enabled) checked="checked" #end/&gt;
 &lt;input type="hidden"   class="uix-pointid"  name="${fieldName}_${extension.id}_extensionPointId" value="${extension.uix.getExtensionPointId()}" /&gt;
 &lt;input type="hidden"   class="uix-order"    name="${fieldName}_${extension.id}_order" value="" /&gt;
 {{/html}}##

--- a/components/widgets/ui/src/main/resources/PhenoTips/ImageDisplayer.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/ImageDisplayer.xml
@@ -92,7 +92,7 @@
     #set ($options.isImage = false)
   #end
 #end
-#set ($qString = "doc=$!escapetool.url($!{targetDoc.fullName})&amp;property=$!{property}&amp;classname=$!escapetool.url($!{object.xWikiClass.name})&amp;object=${object.number}")
+#set ($qString = "doc=$!escapetool.url($!{targetDoc.fullName})&amp;amp;property=$!{property}&amp;amp;classname=$!escapetool.url($!{object.xWikiClass.name})&amp;amp;object=${object.number}")
 
 #if ($options.filter &amp;&amp; $options.filter.size() &gt; 0)
   #foreach($item in $options.filter)
@@ -198,7 +198,7 @@ $content
       #if ($options.manage)
         #__displayUploadForm($targetDoc)
       #else
-        #set ($actionURL = $displayer.getURL('view', "$!{qString}&amp;mode=edit&amp;manage=true"))
+        #set ($actionURL = $displayer.getURL('view', "$!{qString}&amp;amp;mode=edit&amp;amp;manage=true"))
         {{html wiki=false clean=false}}&lt;div class="actions"&gt;&lt;label class="create-button-label"&gt;+&lt;/label&gt;&lt;span class="buttonwrapper"&gt;&lt;a class="add-data-button button manage-images-button" href="${actionURL}"&gt;$services.localization.render('phenotips.imageDisplayer.uploadAndManage')&lt;/a&gt;&lt;/span&gt;&lt;/div&gt;{{/html}}
       #end
       #__displaySelectableAttachmentList($targetDoc $propValue)


### PR DESCRIPTION
There are numerous XHTML syntax errors in PhenoTips that prevent scraping pages as XML. The multiplicity of syntax errors also makes it hard to find other, more serious problems.