### PR TITLE
Fix for and id attributes to link labels to inputs

### DIFF
--- a/components/application-configuration/ui/src/main/resources/PhenoTips/DBConfigurationClass.xml
+++ b/components/application-configuration/ui/src/main/resources/PhenoTips/DBConfigurationClass.xml
@@ -51,7 +51,7 @@
       <customDisplay>{{velocity}}
 #if ($xcontext.action == 'edit' || $xcontext.action == 'admin')
 {{html wiki=false clean=false}}
-&lt;select name="$prefix$name" id="$prefix$iname"&gt;
+&lt;select name="$prefix$name" id="$prefix$name"&gt;
 #foreach ($val in ['MM/dd/yyyy', 'dd/MM/yyyy', 'yyyy-MM-dd', 'MM/yyyy', 'MMMM yyyy'])
   &lt;option #if ($val == $value) selected="selected"#end value="$val"&gt;$val $services.localization.render('phenotips.DBConfigurationClass.dateExample',[$xwiki.formatDate($util.date, $val)])&lt;/option&gt;
 #end
@@ -94,7 +94,7 @@ $!value
 #set ($docFields = ['doc.name', 'doc.creator', 'doc.author', 'doc.creationDate', 'doc.date'])
 #macro(__xclass__displayLivetableColOption $option $value)
   &lt;li&gt;
-    &lt;label for="${prefix}${name}_${sectionId}"&gt;
+    &lt;label&gt;
     &lt;input type="checkbox" name="${prefix}${name}" id="${prefix}${name}_${option}" value="$option"#if ($value.contains($option)) checked="checked"#end/&gt;
     $services.localization.render("patient.livetable.${option}")
     &lt;/label&gt;
@@ -148,7 +148,7 @@ $!value
       <customDisplay>{{velocity}}
 #if ($type == 'edit')
 {{html clean="false"}}
-&lt;select name="${prefix}${name}"&gt;
+&lt;select name="${prefix}${name}" id="${prefix}${name}"&gt;
 #foreach($column in $object.getProperty('livetableColumns').value)
   &lt;option value="$escapetool.xml($column)"#if ($column == $value) selected="selected"#{end}&gt;$services.localization.render("patient.livetable.${column}")&lt;/option&gt;
 #end

--- a/resources/ui/src/main/resources/XWiki/ConfigurableClassMacros.xml
+++ b/resources/ui/src/main/resources/XWiki/ConfigurableClassMacros.xml
@@ -261,10 +261,14 @@
         #set ($out = $out.substring($out.indexOf('&lt;'), $mathtool.add(1, $out.lastIndexOf('&gt;'))))
         ## Step 3: Prepend app name to all ID and FOR attributes to prevent id collision with multiple apps on one page.
         #set ($out = $out.replaceAll(
-            " id='$objClass.getName()_$obj.getNumber()_$propName", " id='${escapedAppName}_$objClass.getName()_$obj.getNumber()_$propName").replaceAll(
-            " for='$objClass.getName()_$obj.getNumber()_$propName", " for='${escapedAppName}_$objClass.getName()_$obj.getNumber()_$propName"))
+            "( id=['""])($objClass.getName()_$obj.getNumber()_$propName)", "$1${escapedAppName}_$2").replaceAll(
+            "( for=['""])($objClass.getName()_$obj.getNumber()_$propName)", "$1${escapedAppName}_$2"))
         ## App Name is prepended to for= to make label work with id which is modified to prevent collisions.
-        &lt;dt&gt;&lt;label for="${escapedAppName}_$objClass.getName()_$obj.getNumber()_$propName"&gt;
+        &lt;dt&gt;&lt;label
+        #if ($out.matches("id=['""]${escapedAppName}_$objClass.getName()_$obj.getNumber()_$propName"))
+          for="${escapedAppName}_$objClass.getName()_$obj.getNumber()_$propName"
+        #end
+        &gt;
         #if ($out.indexOf('type=''checkbox''') != -1 &amp;&amp; $out.indexOf('class="xwiki-form-listclass"') == -1)
           $out
           #set ($out = '')


### PR DESCRIPTION
ConfigurableClassMacros.xml expects attributes to be single-quoted just
like the ones that XWiki generates are. If double quotes are used
instead, it will change the for attributes on the labels without
changing the id attributes on the inputs to match.

If the input is inside a label tag, or there is no input tag at all, the
for attribute is not necessary.