### PR TITLE
[misc] alignment of '+' signs in buttons of gene-variant section

### DIFF
--- a/components/skin/ui/src/main/resources/PhenoTips/Skin.xml
+++ b/components/skin/ui/src/main/resources/PhenoTips/Skin.xml
@@ -461,7 +461,7 @@ label.create-button-label, .add-data-button:before {
   position: absolute;
   text-align: center;
   text-shadow: none;
-  top: .24em;
+  top: .1em;
   vertical-align: middle;
   width: .8em !important;
   z-index: 2;


### PR DESCRIPTION
Poor alignment of '+' signs in `Add variant` and `Add gene` buttons