### PR TITLE
Escape ampersands on administration pages

### DIFF
--- a/components/navigation/ui/src/main/resources/data/WebHome.xml
+++ b/components/navigation/ui/src/main/resources/data/WebHome.xml
@@ -1538,7 +1538,7 @@ $!value
 
 #end
 {{html clean=false}}
-&lt;form class="xformInline" action="$doc.getURL($xcontext.action, $request.queryString)" method="post"&gt;&lt;div&gt;
+&lt;form class="xformInline" action="$escapetool.xml($doc.getURL($xcontext.action, $request.queryString))" method="post"&gt;&lt;div&gt;
   &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
   &lt;input type="hidden" name="doCreate" value="1" /&gt;
   &lt;input type="hidden" name="classTemplate" value="PhenoTips.PhenotypeMappingTemplate" /&gt;

--- a/components/patient-data-sharing/push-ui/src/main/resources/PhenoTips/PushPatientConfiguration.xml
+++ b/components/patient-data-sharing/push-ui/src/main/resources/PhenoTips/PushPatientConfiguration.xml
@@ -63,7 +63,7 @@ $xwiki.ssx.use($displayDocumentName)##
 &lt;div class="hidden"&gt;
     &lt;input type="hidden" name="form_token" value="${escapetool.xml($services.csrf.token)}" /&gt;
     &lt;input type="hidden" name="classname" value="${serverConfigurationClassname}" /&gt;
-    &lt;input type="hidden" name="xredirect" value="${doc.getURL($xcontext.action, $request.queryString)}" /&gt;
+    &lt;input type="hidden" name="xredirect" value="${escapetool.xml($doc.getURL($xcontext.action, $request.queryString))}" /&gt;
   &lt;/div&gt;
 {{/html}}
   #__extradata_displayTable($serverConfigurationClassname, {'counter' : false, 'labels' : false, 'mode' : 'edit', 'addedDisplaySheet' : $displayDocumentName})

--- a/components/patient-data-sharing/receiver-ui/src/main/resources/data/ReceivePatientConfiguration.xml
+++ b/components/patient-data-sharing/receiver-ui/src/main/resources/data/ReceivePatientConfiguration.xml
@@ -66,7 +66,7 @@ $xwiki.ssx.use($displayDocumentName)##
 &lt;div class="hidden"&gt;
     &lt;input type="hidden" name="form_token" value="${escapetool.xml($services.csrf.token)}" /&gt;
     &lt;input type="hidden" name="classname" value="${mainConfigurationClassname}" /&gt;
-    &lt;input type="hidden" name="xredirect" value="${doc.getURL($xcontext.action, $request.queryString)}" /&gt;
+    &lt;input type="hidden" name="xredirect" value="${escapetool.xml($doc.getURL($xcontext.action, $request.queryString))}" /&gt;
   &lt;/div&gt;
   Allow pushes from servers not listed below: ##
 {{/html}}##
@@ -94,7 +94,7 @@ $xwiki.ssx.use($displayDocumentName)##
 &lt;div class="hidden"&gt;
     &lt;input type="hidden" name="form_token" value="${escapetool.xml($services.csrf.token)}" /&gt;
     &lt;input type="hidden" name="classname" value="${serverConfigurationClassname}" /&gt;
-    &lt;input type="hidden" name="xredirect" value="${doc.getURL($xcontext.action, $request.queryString)}" /&gt;
+    &lt;input type="hidden" name="xredirect" value="${escapetool.xml($doc.getURL($xcontext.action, $request.queryString))}" /&gt;
   &lt;/div&gt;
 {{/html}}
   #__extradata_displayTable($serverConfigurationClassname, {'counter' : false, 'labels' : false, 'mode' : 'edit', 'addedDisplaySheet' : $displayDocumentName})

--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientConsentConfiguration.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientConsentConfiguration.xml
@@ -65,7 +65,7 @@ $xwiki.jsx.use($displayDocName)##
 &lt;form action="${consentsDoc.getURL('save')}" method="post"&gt;
 &lt;div class="hidden"&gt;
     &lt;input type="hidden" name="form_token" value="${escapetool.xml($services.csrf.token)}" /&gt;
-    &lt;input type="hidden" name="xredirect" value="${xredirect}" /&gt;
+    &lt;input type="hidden" name="xredirect" value="${escapetool.xml($xredirect)}" /&gt;
     &lt;input type="hidden" name="classname" value="${consentClassname}" /&gt;
   &lt;/div&gt;
 {{/html}}

--- a/components/user-profile-ui/src/main/resources/XWiki/AdminUserProfileSheet.xml
+++ b/components/user-profile-ui/src/main/resources/XWiki/AdminUserProfileSheet.xml
@@ -96,7 +96,7 @@
         &lt;span class='buttonwrapper'&gt;
           &lt;input class='button' type='submit' name='save' value="$services.localization.render('platform.user.profileConfigureSaveButtonLabel')"/&gt;
         &lt;/span&gt;
-        &lt;input type='hidden' name='xredirect' value="$xredirect" /&gt;
+        &lt;input type='hidden' name='xredirect' value="$escapetool.xml($xredirect)" /&gt;
         &lt;input type='hidden' name='form_token' value="$formToken" /&gt;
       &lt;/dt&gt;
     #end

--- a/resources/ui/src/main/resources/PhenoTips/UIX Directory.xml
+++ b/resources/ui/src/main/resources/PhenoTips/UIX Directory.xml
@@ -109,7 +109,7 @@ Sort UI extensions alphabetically by: ##
 
 #end
 {{html clean=false}}
-&lt;form class="xformInline" action="$doc.getURL($xcontext.action, $request.queryString)" method="post"&gt;&lt;div&gt;
+&lt;form class="xformInline" action="$escapetool.xml($doc.getURL($xcontext.action, $request.queryString))" method="post"&gt;&lt;div&gt;
   &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
   &lt;input type="hidden" name="doCreate" value="1" /&gt;
   &lt;input type="hidden" name="classTemplate" value="$uixTemplate" /&gt;


### PR DESCRIPTION
This fixes the syntax of the "Patient data consents configuration", "Phenotypes displayed by default", "Receive Patient configuration", "UIX", and "User Profile" pages.