### PR TITLE
PT-2435: Use underscores rather than spaces in pedigree export filenames.

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/exportSelector.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/exportSelector.js
@@ -125,7 +125,7 @@ define([
         _onExportStarted: function() {
             this.hide();
 
-            var patientDocument = XWiki.currentDocument.page + " pedigree";
+            var patientDocument = XWiki.currentDocument.page + "_pedigree";
 
             var exportType = $$('input:checked[type=radio][name="export-type"]')[0].value;
             //console.log("Import type: " + exportType);


### PR DESCRIPTION
Fixed.