### PR TITLE
PT-924: The "quick fix" for displaying hand length percentile when taken < 2 years old.

### DIFF
--- a/components/patient-measurements/ui/src/main/resources/PhenoTips/MeasurementsClass.xml
+++ b/components/patient-measurements/ui/src/main/resources/PhenoTips/MeasurementsClass.xml
@@ -394,10 +394,10 @@
 #set ($dValue = $object.getProperty('hand').value)
 #set ($age = $object.getProperty('age').value)
 #set ($male = $doc.getObject('PhenoTips.PatientClass').getProperty('gender').value != 'F')
-#if ("$!dValue" == '' || "$!{age}" == '' )
+#set ($pValue = $services.measurements.hand.valueToPercentile($male, $age, $dValue))
+#if ("$!dValue" == '' || "$!{age}" == '' || "$!pValue" == '-1')
   #set ($dValue = '-')
 #else
-  #set ($pValue = $services.measurements.hand.valueToPercentile($male, $age, $dValue))
   #set ($sdValue = $mathtool.roundTo(2, $services.measurements.hand.valueToStandardDeviation($male, $age, $dValue)))
   #set ($dValue = "${pValue}#if($pValue&lt;=20 &amp;&amp; $pValue&gt;=4)^^th^^#elseif($pValue%10==1)^^st^^#elseif($pValue%10==2)^^nd^^#elseif($pValue%10==3)^^rd^^#{else}^^th^^#end pctl (#if ($sdValue &gt;= 0)+#end${sdValue}SD~)")
 #end
@@ -436,10 +436,10 @@
 #set ($dValue = $object.getProperty('hand_right').value)
 #set ($age = $object.getProperty('age').value)
 #set ($male = $doc.getObject('PhenoTips.PatientClass').getProperty('gender').value != 'F')
-#if ("$!dValue" == '' || "$!{age}" == '' )
+#set ($pValue = $services.measurements.hand.valueToPercentile($male, $age, $dValue))
+#if ("$!dValue" == '' || "$!{age}" == '' || "$!pValue" == '-1')
   #set ($dValue = '-')
 #else
-  #set ($pValue = $services.measurements.hand.valueToPercentile($male, $age, $dValue))
   #set ($sdValue = $mathtool.roundTo(2, $services.measurements.hand.valueToStandardDeviation($male, $age, $dValue)))
   #set ($dValue = "${pValue}#if($pValue&lt;=20 &amp;&amp; $pValue&gt;=4)^^th^^#elseif($pValue%10==1)^^st^^#elseif($pValue%10==2)^^nd^^#elseif($pValue%10==3)^^rd^^#{else}^^th^^#end pctl (#if ($sdValue &gt;= 0)+#end${sdValue}SD~)")
 #end


### PR DESCRIPTION
From JIRA: "The quick fix is to display nothing if we get -1 on evaluation. The better fix is to get the data for 0-2y."