### PR TITLE
Add DurationField widget

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheet.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheet.xml
@@ -57,6 +57,7 @@ $xwiki.jsfx.use('js/scriptaculous/dragdrop.js')##
 $xwiki.ssfx.use('uicomponents/widgets/validation/livevalidation.css', true)##
 $xwiki.jsfx.use('uicomponents/widgets/validation/livevalidation_prototype.js')##
 $xwiki.jsfx.use('uicomponents/widgets/validation/scrollValidation.js')##
+$xwiki.jsfx.use('uicomponents/widgets/durationField.js', true)##
 ##
 ##
 #set($config = $xwiki.getDocument("${doc.space}.WebHome").getObject('PhenoTips.DBConfigurationClass'))

--- a/components/widgets/api/src/main/resources/ApplicationResources.properties
+++ b/components/widgets/api/src/main/resources/ApplicationResources.properties
@@ -41,6 +41,7 @@ phenotips.widgets.multiSuggest.clear.title=Clear the list of selected suggestion
 phenotips.widgets.multiSuggest.clear=Delete all
 phenotips.widgets.suggest.hideSuggestions=hide suggestions
 phenotips.widgets.workgroupPicker.noResults=Group not found
+phenotips.widgets.durationField.invalid=Invalid timespan
 
 phenotips.yesNoNAPicker.NA.title=NA (irrelevant or unknown)
 phenotips.yesNoNAPicker.NA.unselectedTitle=Unselect

--- a/components/widgets/resources/src/main/resources/resources/uicomponents/widgets/durationField.js
+++ b/components/widgets/resources/src/main/resources/resources/uicomponents/widgets/durationField.js
@@ -1,0 +1,116 @@
+var PhenoTips = (function(PhenoTips) {
+  // Start PhenoTips augmentation
+  var widgets = PhenoTips.widgets = PhenoTips.widgets || {};
+
+  widgets.DurationField = Class.create({
+    pieces : {
+      y : 'years',
+      m : 'months',
+      w : 'weeks',
+      d : 'days',
+      n : '([0-9]*)',
+      s : '\\s*'
+    },
+    initialize : function(element) {
+      if (!element) {
+        return;
+      }
+      var sep = this.pieces.s;
+      this.subgroups = {
+        y  : this._regexpifyDurationUnit('y', true),
+        m  : this._regexpifyDurationUnit('m', true),
+        w  : this._regexpifyDurationUnit('w', true),
+        d  : this._regexpifyDurationUnit('d', true)
+      };
+      this.regexp = new RegExp("^((" + this.subgroups.y + sep + this.subgroups.m + ")|" + this.subgroups.w + ")" + sep + this.subgroups.d + "$");
+      this.element = element;
+      var _this = this;
+      ['keyup', 'input', 'duration:change'].each(function(ev) {
+        element.observe(ev, function(event) {
+          if (_this.regexp.match(element.value)) {
+            element.removeClassName('error');
+          } else {
+            element.addClassName('error');
+          }
+        });
+      });
+      ['blur', 'duration:change'].each(function(ev) {
+        element.observe(ev, function(event) {
+          element.value = _this.format(element.value);
+          element.title = _this.getValue(element.value);
+          Element.fire(element, 'duration:format');
+        });
+      });
+
+      // Set up validation
+      this._validate = this._validate.bind(this);
+      this.element.__validation = this.element.__validation || new LiveValidation(this.element, {validMessage: '', wait: 500});
+      this.element.__validation.add(this._validate);
+
+      element.value = _this.format(element.value);
+      element.title = _this.getValue(element.value);
+      element.__durationField = this;
+    },
+    _regexpifyDurationUnit : function(unit, makeOptional) {
+      return "(" + this.pieces.s + this.pieces.n + this.pieces.s + this._regexpifyWord(this.pieces[unit] || "") + this.pieces.s + ")" + (makeOptional ? '?' : '');
+    },
+    _regexpifyWord : function(word) {
+      return word.replace(/(.)/g, "$1?").replace("?", "");
+    },
+    match : function(text) {
+      return (text || "").match(this.regexp);
+    },
+    getValue : function(text) {
+      if (this.match(text)) {
+        var result = 0;
+        var _this = this;
+        var item;
+        [['y', 12], ['m', 1], ['w', 0.23], ['d', 0.03286]].each(function(unit) {
+          item = text.match(new RegExp(this._regexpifyDurationUnit(unit[0], false)));
+          if (item) {
+            result += item[2] * unit[1];
+          }
+        }.bind(this));
+        return result;
+      } else {
+        return -1;
+      }
+    },
+    format : function(text) {
+      if (this.match(text)) {
+        var result = text;
+        var _this = this;
+        ['y', 'm', 'w', 'd'].each(function(unit) {
+          result = result.replace(new RegExp(this._regexpifyDurationUnit(unit, false)), "$2" + this.pieces[unit][0]);
+        }.bind(this));
+        return result.replace(this.pieces.sep, "", "g");
+      } else {
+        return text;
+      }
+    },
+    _validate: function() {
+      if (this.regexp.match(this.element.value)) {
+        return true;
+      } else {
+        Validate.fail("$services.localization.render('phenotips.widgets.durationField.invalid')");
+      }
+    }
+  });
+
+  var init = function(event) {
+    ((event && event.memo.elements) || [$('body')]).each(function(element) {
+      element.select('input[type="text"].pt-duration').each(function(item) {
+        if (!item.__durationField) {
+          new PhenoTips.widgets.DurationField(item);
+        }
+      });
+    });
+    return true;
+  };
+
+  (XWiki.domIsLoaded && init()) || document.observe("xwiki:dom:loaded", init);
+  document.observe("xwiki:dom:updated", init);
+
+  // End PhenoTips augmentation.
+  return PhenoTips;
+}(PhenoTips || {}));


### PR DESCRIPTION
This widget was already added to [`feature-measurements`](/phenotips/phenotips/tree/feature-measurements), as `DurationValidator`. I needed to make a few important changes for [`phenotype-meta-exact-onset`](/phenotips/phenotips/tree/phenotype-meta-exact-onset), so I created a separate branch for it. I have already merged it into [`feature-measurements`](/phenotips/phenotips/tree/feature-measurements) and will fix that branch as necessary.