### PR TITLE
Reworded heading name to reduce admin confusion

### DIFF
--- a/components/patient-measurements/api/src/main/resources/ApplicationResources.properties
+++ b/components/patient-measurements/api/src/main/resources/ApplicationResources.properties
@@ -31,7 +31,7 @@ PhenoTips.MeasurementsConfigurationClass_measurementUnitSystem_imperial=Imperial
 
 phenotips.MeasurementsConfigurationClass.unitSystemHeader=Unit System
 phenotips.MeasurementsConfigurationClass.measurementTypesHeader=Measurement Types
-phenotips.MeasurementsConfigurationClass.default=Recommended
+phenotips.MeasurementsConfigurationClass.default=Fixed
 phenotips.MeasurementsConfigurationClass.expanded=Expanded
 
 phenotips.patientSheet.measurements.showExpandedMeasurements=Show more


### PR DESCRIPTION
Discussed with Courtney. Measurements info box states that "It is recommended to record weight, height and head circumference for all patients." Since this is a static description that does not change when items are set as "Recommended" by the admin, we decided that that the administration field name should be changed from "Recommended" to "Fixed".