### PR TITLE
Fixed DateTimePicker for NIAID

### DIFF
--- a/components/widgets/ui/src/main/resources/XWiki/DateTimePicker.xml
+++ b/components/widgets/ui/src/main/resources/XWiki/DateTimePicker.xml
@@ -2344,7 +2344,7 @@ CalendarDateSelect = Class.create({
       this.options = Object.extend(Object.clone(this.options), options || {});
       this.attachPickers();
       document.observe('xwiki:dom:updated', function(event) {
-        this.attachPickers(event.memo.element);
+        this.attachPickers(event.memo.elements);
       }.bindAsEventListener(this));
     },
     attachPickers : function (container) {

--- a/components/widgets/ui/src/main/resources/XWiki/DateTimePicker.xml
+++ b/components/widgets/ui/src/main/resources/XWiki/DateTimePicker.xml
@@ -2343,6 +2343,9 @@ CalendarDateSelect = Class.create({
     initialize : function(options) {
       this.options = Object.extend(Object.clone(this.options), options || {});
       this.attachPickers();
+      document.observe('xwiki:dom:updated', function(event) {
+        this.attachPickers(event.memo.element);
+      }.bindAsEventListener(this));
     },
     attachPickers : function (container) {
       var dateInputs = container &amp;&amp; container.select(this.selector) || $$(this.selector);


### PR DESCRIPTION
@veronikaslc @danielpgross Please review.

This change fixes a bug where the DateTimePicker was not appearing on first load for date fields in a new table (project for a Gene42 client).