### PR TITLE
Modify the specificity meter to not fire an event on initialization

### DIFF
--- a/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
+++ b/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
@@ -237,7 +237,7 @@
       var value = this._crtValue * 5;
       this.meterDisplay.title = this.levels[Math.round(value)] + " (" + value.toPrecision(3) + "/5)";
       this.meterDisplay.update(new Element('div', {'id' : "specificity-meter-value", "style" : "width: " + Math.round(v * 100) + "%;"}));
-      if (oldValue != this._crtValue) {
+      if (oldValue !== undefined &amp;&amp; oldValue != this._crtValue) {
         var eventData = {"value": this._crtValue, "level": this.levels[Math.round(value)]};
         document.fire("phenotips:specificity-meter:change", eventData);
       }


### PR DESCRIPTION
Currently, on initialization of the specificity meter (on page load), an event is always fired with value "0", even though this is not the actual specificity score. That event should not be fired because it does not represent an actual change in value, nor does it contain the actual specificity score.

This change is necessary for a downstream module that triggers certain behaviour when the specificity score changes. With the current "false positive" behaviour of the specificity meter, the downstream module does not work properly.