### PR TITLE
Modify the specificity meter to always fire an event on first update

### DIFF
--- a/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
+++ b/components/specificity-meter/ui/src/main/resources/PhenoTips/SpecificityMetricWidget.xml
@@ -203,6 +203,8 @@
       this.service =  new XWiki.Document('SpecificityMetricWidgetService', 'PhenoTips').getURL('get');
       this._reqMeta = {};
 
+      this._firedUpdate = false;
+
       this.initDataCache();
       this.watchChanges();
     },
@@ -237,9 +239,10 @@
       var value = this._crtValue * 5;
       this.meterDisplay.title = this.levels[Math.round(value)] + " (" + value.toPrecision(3) + "/5)";
       this.meterDisplay.update(new Element('div', {'id' : "specificity-meter-value", "style" : "width: " + Math.round(v * 100) + "%;"}));
-      if (oldValue !== undefined &amp;&amp; oldValue != this._crtValue) {
+      if (oldValue !== undefined &amp;&amp; (!this._firedUpdate || oldValue != this._crtValue)) {
         var eventData = {"value": this._crtValue, "level": this.levels[Math.round(value)]};
         document.fire("phenotips:specificity-meter:change", eventData);
+        this._firedUpdate = true;
       }
     },
 


### PR DESCRIPTION
This is a follow-up to https://github.com/phenotips/phenotips/pull/2085. The issue is now that the update event is not fired initially in the case that the score is 0.

This change fixes that issue, making the update event always fire when the score is actually calculated for the first time, even if the score is 0.
