### PR TITLE
PT-2822: In Chrome, the "Advanced data filters" accumulate duplicate entries

### DIFF
--- a/components/widgets/resources/src/main/resources/resources/uicomponents/widgets/exportData.js
+++ b/components/widgets/resources/src/main/resources/resources/uicomponents/widgets/exportData.js
@@ -158,16 +158,22 @@ document.observe('xwiki:dom:loading', function() {
               item._suggestPicker = suggestPicker;
 
               // Format the predefined value
-              item.value.split(',').each(function(value) {
-                item._suggestPicker.addItem(value, value, '', '');
-              });
-              item.value = '';
+              // addItem triggers a URL update, so to avoid creating an entry on
+              // the Back button for each iteration of this loop, keep the URL
+              // the same by removing selections from the textbox as they are
+              // added to the suggest picker
+              var selections = item.value.split(',');
+              while (selections.length) {
+                var selection = selections.shift();
+                item.value = selections.join(',');
+                item._suggestPicker.addItem(selection, selection, '', '');
+              }
             }
             if (tableFilters) {
               // Integrate the custom fields
               // 1. find the container element displaying them
               var source = tableFilters.down('input[type="text"][name="' + item.name + '"]');
-              var selectionContainer = source && source.next('.accepted-suggestions');
+              var selectionContainer = source && source != item && source.next('.accepted-suggestions');
               if (selectionContainer) {
                 // 2. find all the values and display them as part of the multi suggest picker
                 var tmp = suggestPicker.silent;


### PR DESCRIPTION
Fixed duplication of phenotype field

There were actually two problems here:
1. Selections were copied to the URL from both the textbox and the checkboxes, creating duplicate entries in the URL and breaking the Back button.
2. The checkboxes were being duplicated, which rewrote the URL several more times (breaking the Back button more) before returning to the same URL with all entries duplicated.

The fix is to prevent either step from creating a URL with duplicate entries.

Of the problems mentioned in [PT-2822](https://phenotips.atlassian.net/browse/PT-2822), this patch only fixes the phenotype duplication. Separate fixes will be required for the other duplicated fields.

@marta-
