### PR TITLE
PT-2833: "Affected" and the first "Confirmed gene" use the exact same…

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/causalGeneLegend.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/causalGeneLegend.js
@@ -10,7 +10,7 @@
         initialize: function($super) {
             $super('Confirmed Causal Genes', 'genes',
                    "causal",
-                   ["#FEE090", '#f8ebb7', '#eac080', '#bf6632', '#9a4500', '#a47841', '#c95555', '#ae6c57'], // TODO: replace
+                   ['#eac080', '#bf6632', '#9a4500', '#a47841', '#c95555', '#ae6c57'], // TODO: replace
                    "getCausalGenes",
                    "setCausalGenes"); // operation
         }


### PR DESCRIPTION
… color in the pedigree

Removed the first two predefined colors, which are shades of yellow. It's unlikely that there will be that many confirmed causal genes in real life anyway.