### PR TITLE
PT-2871: Delete patient and family functionality is broken

### DIFF
--- a/components/family-studies/api/src/main/java/org/phenotips/studies/family/internal/PhenotipsFamilyRepository.java
+++ b/components/family-studies/api/src/main/java/org/phenotips/studies/family/internal/PhenotipsFamilyRepository.java
@@ -139,9 +139,6 @@ public class PhenotipsFamilyRepository implements FamilyRepository
         if (!canDeleteFamily(family, updatingUser, deleteAllMembers, false)) {
             return false;
         }
-        if (!this.forceRemoveAllMembers(family, updatingUser)) {
-            return false;
-        }
         if (deleteAllMembers) {
             for (Patient patient : family.getMembers()) {
                 if (!this.patientRepository.delete(patient)) {
@@ -150,7 +147,10 @@ public class PhenotipsFamilyRepository implements FamilyRepository
                     return false;
                 }
             }
+        } else if (!this.forceRemoveAllMembers(family, updatingUser)) {
+            return false;
         }
+
         try {
             XWikiContext context = this.provider.get();
             XWiki xwiki = context.getWiki();

--- a/components/pedigree/ui/src/main/resources/PhenoTips/PedigreeMacros.xml
+++ b/components/pedigree/ui/src/main/resources/PhenoTips/PedigreeMacros.xml
@@ -379,7 +379,7 @@
               deleteFamilyButton.observe("click", function(event) {
                 event.stop();
                 confirmationDialog.closeDialog();
-                var parameters = {"action": "deletefamily", "removemembers": false, "family_id": familyId};
+                var parameters = {"action": "deletefamily", "removemembers": false, "family_id": familyId, "form_token": $$('meta[name=form_token]')[0].content};
                  sendDeleteRequest(parameters);
               });
             }

--- a/components/skin/ui/src/main/resources/PhenoTips/ContentTopMenu.xml
+++ b/components/skin/ui/src/main/resources/PhenoTips/ContentTopMenu.xml
@@ -294,7 +294,7 @@
                                        "$services.localization.render('phenotips.patientRecord.pedigree.deleteFamilyWarning')" + " " + familyString + "." +
                                        "$services.localization.render('phenotips.patientRecord.pedigree.deleteFamilyWarningQuestion')" + "&lt;br&gt;&lt;br&gt;";
                 var parameters = {"action": "deletefamily", "removemembers": true, "family_id": familyId};
-                standardPatientDelete(confirmationText);
+                standardPatientDelete(confirmationText, familyId);
               } else {
                 standardPatientDelete();
               }
@@ -305,7 +305,7 @@
     }
   }
 
-  var standardPatientDelete = function (confirmationText) {
+  var standardPatientDelete = function (confirmationText, familyId) {
     var item = $('prActionDelete');
     var url = item.readAttribute('href') + "?confirm=1&amp;form_token=" + $$('meta[name=form_token]')[0].content + (Prototype.Browser.Opera ? "" : "&amp;ajax=1");
     if (confirmationText)
@@ -349,7 +349,7 @@
       deleteFamilyButton.observe("click", function(event) {
           event.stop();
           confirmationDialog.closeDialog();
-          var parameters = {"action": "deletefamily", "removemembers": true, "family_id": familyId};
+          var parameters = {"action": "deletefamily", "removemembers": true, "family_id": familyId, "form_token": $$('meta[name=form_token]')[0].content};
           sendDeleteRequest(parameters);
      });
     }


### PR DESCRIPTION
Fixed 3 problems:
- `deleteFamily` workflow was wrong when the deletion of all members was requested
- Family Id got "lost" before actually sending the request to delete the family
- CSRF token was not sent from client side for the `deletefamily` action