### PR TITLE
[bug] Classname 'selected' to be appended only once when input is checked

### DIFF
--- a/components/widgets/ui/src/main/resources/PhenoTips/ImageDisplayer.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/ImageDisplayer.xml
@@ -473,7 +473,12 @@ $content
         var image = item.down('.attachment-preview img');
         var viewlink = item.down('a.view.hidden');
         var id = input.id.substring(XWiki.MultiImageSelector.prototype.DEDUPLICATION_PREFIX.length);
-        var lItem = new Element('div', {'class' : item.className + (input.checked &amp;&amp; ' selected' || '')});
+        if (input.checked &amp;&amp; !item.hasClassName('selected')) {
+          item.addClassName('selected');
+        } else if (!input.checked &amp;&amp; item.hasClassName('selected')) {
+          item.removeClassName('selected'); 
+        }
+        var lItem = new Element('div', {'class' : item.className});
         lItem.insert({
                   'top' : new Element('label', {'for' : id, 'title' : input.value}).update(input.value).insert({
                               top : new Element('input', {


### PR DESCRIPTION
Requesting change for line 476 to simplify applying CSS rules to show only file attachment items that are actually `selected` (when `input.checked == true`). 

The current behaviour does not remove the `selected` class name from the `attachment-item` div when `input.checked` becomes `false`, resulting in extra `selected` class names appended. Unclicking and reclicking the same attachment item produces this.

Please review @veronikaslc. Thanks.