### PR TITLE
PT-2961: Legend is broken in pedigree editor

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/editor.css
+++ b/components/pedigree/resources/src/main/resources/pedigree/editor.css
@@ -237,8 +237,6 @@
   z-index: 10000;
   min-width: 140px;
   max-width: 255px;
-  max-height: 100%;
-  overflow-y: scroll;
 }
 .legend-container span {
   font-family: Arial,Verdana,sans-serif;


### PR DESCRIPTION
Reverting commits done for PT-2866: Pedigree legend does not scale if there are many annotations (eg ~30 phenotypes), which are causing the problem (PR #2154).