### PR TITLE
Fixing regressions introduced by PT-2932 (PT-3021, PT-3022, PT-3031)

### DIFF
--- a/components/export/ui/src/main/resources/PhenoTips/ExportPreferences.xml
+++ b/components/export/ui/src/main/resources/PhenoTips/ExportPreferences.xml
@@ -229,8 +229,8 @@
  )))##section filters
 #end
 
+#set($selectionTools = "&lt;div class='selection-tools'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.label') &lt;span class='selection-tool select-all'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.all')&lt;/span&gt; · &lt;span class='selection-tool select-none'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.none')&lt;/span&gt; · &lt;span class='selection-tool select-invert'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.invert')&lt;/span&gt; · &lt;span class='selection-tool select-restore'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.restore')&lt;/span&gt;&lt;/div&gt;")
 #if ($request.push)
-  #set($selectionTools = "&lt;div class='selection-tools'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.label') &lt;span class='selection-tool select-all'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.all')&lt;/span&gt; · &lt;span class='selection-tool select-none'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.none')&lt;/span&gt; · &lt;span class='selection-tool select-invert'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.invert')&lt;/span&gt; · &lt;span class='selection-tool select-restore'&gt;$services.localization.render('phenotips.DBWebHomeSheet.colSelect.restore')&lt;/span&gt;&lt;/div&gt;")
   #if ($request.multipatient)
     (% class="push-fields section columns"%)(((
     === (% class="step" %)2(%%) $services.localization.render('phenotips.exportPreferences.selectFields') ===
@@ -249,6 +249,7 @@
 #else
   (% class="section columns"%)(((
   === (% class="step" %)2(%%) $services.localization.render('phenotips.exportPreferences.selectFields') ===
+  {{html clean="false"}}$selectionTools{{/html}}##
   #__export__displayFieldList( "PhenoTips.PatientClass" 'columns' $customValues $ignored $codeFields $selectedValues $simple)
   #set($exportTitle = "$services.localization.render('phenotips.exportPreferences.export')")
   #set($exportButtonID = "export-multiple-patients")


### PR DESCRIPTION
In [this commit for PT-2932](https://github.com/phenotips/phenotips/commit/b791fcb56dced61ad895b1bb9a7b8396acb17726), the generation of the selection tools was moved from JavaScript to Velocity, but now the selection tools are generated ONLY in the push dialog, not the Export Excel/JSON dialog. However, [the JavaScript still tried to attach behaviors to the (non-existing) tools](https://github.com/phenotips/phenotips/commit/b791fcb56dced61ad895b1bb9a7b8396acb17726#diff-beef42dea801bc57f407ac4f98c830d4R317) which produced an error and prevented the rest of the code from running.