### PR TITLE
PT-2843: On the Family page, the family identifier label and the corr…

### DIFF
--- a/components/family-studies/ui/src/main/resources/PhenoTips/FamilyRecordField_externalId.xml
+++ b/components/family-studies/ui/src/main/resources/PhenoTips/FamilyRecordField_externalId.xml
@@ -112,20 +112,11 @@
 
 {{velocity}}
 #if($xcontext.action == 'edit' || $doc.display('external_id') != '')
-  #if ($xcontext.action != 'edit')
-    (((#__form_label('external_id')
-       #__form_field('external_id'))))
-  #else
-    (% class="fieldset external_id" %)(((
-      (% class="half-width external_id" %)(((
-        #__form_label('external_id' 'section')
-      )))
-      (% class="half-width external_id" %)(((
-      #__form_field('external_id')
-      )))
-      (% class="clear" %)((()))
-    )))
-  #end
+  (% class="fieldset external_id" %)(((
+    #__form_label('external_id' 'section')
+
+    #__form_field('external_id')
+  )))
 #end
 {{/velocity}}</content>
     </property>


### PR DESCRIPTION
…esponding field should be closer

Quick fix to stack the label and the value vertically. This layout fits better with the current family form. Should be revisited once we redo the whole PhenoTips UI.