### PR TITLE
[misc] Tooltip layout fix

### DIFF
--- a/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
@@ -6324,9 +6324,6 @@ div.resultContainer div.sourceContent.loading {
   margin: 0 0 0 1em;
   padding: 0;
 }
-.ontology-tree .hint {
-  margin-left: 1.6em;
-}
 .ontology-tree .entry-tools {
   /* float: right; */
   display: inline-block;


### PR DESCRIPTION
This rule caused the link to HPO to be misplaced in tooltips inside the Ontology browser. It's 5y old and doesn't seem to have any other effects anymore.

Before:
![image](https://cloud.githubusercontent.com/assets/651980/24165310/681f27aa-0e46-11e7-8c48-c0286fdc9ab2.png)

After:
![image](https://cloud.githubusercontent.com/assets/651980/24165344/7dcfbc22-0e46-11e7-8899-0cf3d7524c34.png)
