### PR TITLE
PT-3166: HPO Ids should not be visible in phenotype suggestions

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/UIX_Field__phenotype.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/UIX_Field__phenotype.xml
@@ -551,7 +551,7 @@
 #diffDiagnosis-search-results ul li {
   margin: 0;
 }
-#diffDiagnosis-search-results ul .id {
+#diffDiagnosis-search-results ul .term-id {
   display: none;
 }
 


### PR DESCRIPTION
Fixed.