### PR TITLE
PT-3167: Fix punctuation in update failure message

### DIFF
--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/PatientAccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/PatientAccessRightsManagement.xml
@@ -763,7 +763,7 @@
             if (response.statusText == '' /* No response */ || response.status == 12031 /* In IE */) {
                failureReason = "$services.localization.render('phenotips.patientAccessRightsManagement.modifyNoServerResponse')";
             }
-            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$services.localization.render('phenotips.patientAccessRightsManagement.modifyUpdateFailure')" + " " + failureReason));
+            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$services.localization.render('phenotips.patientAccessRightsManagement.modifyUpdateFailure') " + failureReason));
           },
           on0 : function (response) {
             response.request.options.onFailure(response);

--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/PatientAccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/PatientAccessRightsManagement.xml
@@ -763,7 +763,7 @@
             if (response.statusText == '' /* No response */ || response.status == 12031 /* In IE */) {
                failureReason = "$services.localization.render('phenotips.patientAccessRightsManagement.modifyNoServerResponse')";
             }
-            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$services.localization.render('phenotips.patientAccessRightsManagement.modifyUpdateFailure')" + failureReason));
+            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$services.localization.render('phenotips.patientAccessRightsManagement.modifyUpdateFailure')" + " " + failureReason));
           },
           on0 : function (response) {
             response.request.options.onFailure(response);


### PR DESCRIPTION
"Failed to update.[reason]" changed to "Failed to update. [reason]"