### PR TITLE
PT-3034: Allow method PATCH on patient resources

### DIFF
--- a/components/patient-data/rest/pom.xml
+++ b/components/patient-data/rest/pom.xml
@@ -30,7 +30,7 @@
 
   <properties>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <coverage.instructionRatio>0.74</coverage.instructionRatio>
+    <coverage.instructionRatio>0.75</coverage.instructionRatio>
   </properties>
 
   <dependencies>

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByExternalIdResource.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByExternalIdResource.java
@@ -17,6 +17,7 @@
  */
 package org.phenotips.data.rest;
 
+import org.phenotips.rest.PATCH;
 import org.phenotips.rest.ParentResource;
 import org.phenotips.rest.Relation;
 import org.phenotips.rest.RequiredAccess;
@@ -76,6 +77,24 @@ public interface PatientByExternalIdResource
     @RequiredAccess("edit")
     Response updatePatient(String json, @PathParam("eid") String eid,
         @QueryParam("policy") @DefaultValue("update") String policy);
+
+    /**
+     * Update a patient record, identified by its given "external" identifier, from its JSON representation. Existing
+     * patient data is merged with the provided JSON representation, if possible. If the user sending the request
+     * doesn't have the right to edit the target patient record, no change is performed and an error is returned. If the
+     * indicated patient record doesn't exist, and a valid JSON is provided, a new patient record is created with the
+     * provided data. If multiple records exist with the same given identifier, no change is performed, and a list of
+     * links to each such record is returned. If a field is set in the patient record, but missing in the JSON, then
+     * that field is not changed.
+     *
+     * @param json the JSON representation of the new patient to add
+     * @param eid the patient's given "external" identifier, see {@link org.phenotips.data.Patient#getExternalId()}
+     * @return a status message
+     */
+    @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RequiredAccess("edit")
+    Response patchPatient(String json, @PathParam("eid") String eid);
 
     /**
      * Delete a patient record, identified by its given "external" identifier. If the indicated patient record doesn't

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientResource.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientResource.java
@@ -17,6 +17,7 @@
  */
 package org.phenotips.data.rest;
 
+import org.phenotips.rest.PATCH;
 import org.phenotips.rest.ParentResource;
 import org.phenotips.rest.Relation;
 import org.phenotips.rest.RequiredAccess;
@@ -73,6 +74,22 @@ public interface PatientResource
     @RequiredAccess("edit")
     Response updatePatient(String json, @PathParam("patient-id") String id,
         @QueryParam("policy") @DefaultValue("update") String policy);
+
+    /**
+     * Update a patient record, identified by its internal PhenoTips identifier, from its JSON representation. Existing
+     * patient data is merged with the provided JSON representation, if possible. If the indicated patient record
+     * doesn't exist, or if the user sending the request doesn't have the right to edit the target patient record, no
+     * change is performed and an error is returned. If a field is set in the patient record, but missing in the JSON,
+     * then that field is not changed.
+     *
+     * @param json the JSON representation of the new patient
+     * @param id the patient's internal identifier, see {@link org.phenotips.data.Patient#getId()}
+     * @return a status message
+     */
+    @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RequiredAccess("edit")
+    Response patchPatient(String json, @PathParam("patient-id") String id);
 
     /**
      * Delete a patient record, identified by its internal PhenoTips identifier. If the indicated patient record doesn't

--- a/components/patient-data/rest/src/test/java/org/phenotips/data/rest/internal/DefaultPatientByExternalIdResourceImplTest.java
+++ b/components/patient-data/rest/src/test/java/org/phenotips/data/rest/internal/DefaultPatientByExternalIdResourceImplTest.java
@@ -47,6 +47,7 @@ import org.xwiki.users.UserManager;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,8 +57,10 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -86,6 +89,16 @@ import static org.mockito.Mockito.when;
 
 public class DefaultPatientByExternalIdResourceImplTest
 {
+    private static final String EID = "eid";
+
+    private static final String ID = "id";
+
+    private static final String PATIENT_ID = "P0000001";
+
+    private static final String EMPTY_JSON = "{}";
+
+    private static final String EXTERNAL_ID = "external_id";
+
     private static final String UPDATE = "update";
 
     @Rule
@@ -117,21 +130,15 @@ public class DefaultPatientByExternalIdResourceImplTest
 
     private AuthorizationManager access;
 
-    private UserManager users;
-
     private URI uri;
 
     private XWikiContext context;
 
     private DefaultPatientByExternalIdResourceImpl component;
 
-    private final String eid = "eid";
-
-    private final String id = "id";
-
     private DocumentReference userReference = new DocumentReference("wiki", "XWiki", "padams");
 
-    private DocumentReference patientReference = new DocumentReference("wiki", "data", "P0000001");
+    private DocumentReference patientReference = new DocumentReference("wiki", "data", PATIENT_ID);
 
     @Before
     public void setUp() throws ComponentLookupException, URISyntaxException
@@ -150,7 +157,8 @@ public class DefaultPatientByExternalIdResourceImplTest
         this.factory = this.mocker.getInstance(DomainObjectFactory.class);
         this.qm = this.mocker.getInstance(QueryManager.class);
         this.access = this.mocker.getInstance(AuthorizationManager.class);
-        this.users = this.mocker.getInstance(UserManager.class);
+
+        final UserManager users = this.mocker.getInstance(UserManager.class);
         this.component = (DefaultPatientByExternalIdResourceImpl) this.mocker.getComponentUnderTest();
         this.logger = this.mocker.getMockedLogger();
         this.resolver = this.mocker.getInstance(EntityReferenceResolver.TYPE_REFERENCE, "current");
@@ -161,11 +169,11 @@ public class DefaultPatientByExternalIdResourceImplTest
         when(this.resolver.resolve(any(EntityReference.class), any(EntityType.class), any()))
             .thenReturn(mock(EntityReference.class));
         doReturn(this.uriBuilder).when(this.uriInfo).getBaseUriBuilder();
-        when(this.patient.getId()).thenReturn(this.id);
+        when(this.patient.getId()).thenReturn(ID);
         when(this.patient.getDocumentReference()).thenReturn(this.patientReference);
-        when(this.users.getCurrentUser()).thenReturn(this.user);
+        when(users.getCurrentUser()).thenReturn(this.user);
         when(this.user.getProfileDocument()).thenReturn(this.userReference);
-        when(this.repository.getByName(this.eid)).thenReturn(this.patient);
+        when(this.repository.getByName(EID)).thenReturn(this.patient);
         when(this.repository.create()).thenReturn(this.patient);
         when(this.access.hasAccess(Right.VIEW, this.userReference, this.patientReference)).thenReturn(true);
         when(this.access.hasAccess(Right.EDIT, this.userReference, this.patientReference)).thenReturn(true);
@@ -188,7 +196,7 @@ public class DefaultPatientByExternalIdResourceImplTest
     {
         when(this.access.hasAccess(Right.VIEW, this.userReference, this.patientReference)).thenReturn(false);
 
-        Response response = this.component.getPatient(this.eid);
+        Response response = this.component.getPatient(EID);
         verify(this.logger).debug("View access denied to user [{}] on patient record [{}]", this.user,
             this.patient.getId());
 
@@ -204,8 +212,8 @@ public class DefaultPatientByExternalIdResourceImplTest
         when(this.uriBuilder.path(PatientResource.class)).thenReturn(this.uriBuilder);
         when(this.uriBuilder.build(this.patient.getId())).thenReturn(this.uri);
 
-        Response response = this.component.getPatient(this.eid);
-        verify(this.logger).debug("Retrieving patient record with external ID [{}] via REST", this.eid);
+        Response response = this.component.getPatient(EID);
+        verify(this.logger).debug("Retrieving patient record with external ID [{}] via REST", EID);
 
         JSONObject links = new JSONObject().accumulate("rel", "self").accumulate("href", "uri")
             .put("allowedMethods", new JSONArray(Collections.singletonList("GET")));
@@ -219,12 +227,12 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void getPatientNotFoundChecksForMultipleRecords() throws ComponentLookupException, QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
 
-        Response response = this.component.getPatient(this.eid);
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
+        Response response = this.component.getPatient(EID);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
@@ -232,13 +240,13 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void updatePatientNotFoundChecksForMultipleRecords() throws ComponentLookupException, QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
 
-        Response response = this.component.updatePatient("{}", this.eid, UPDATE);
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
-        verify(this.logger).debug("Creating patient record with external ID [{}]", this.eid);
+        Response response = this.component.updatePatient(EMPTY_JSON, EID, UPDATE);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 
@@ -246,13 +254,13 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void updatePatientNotFoundNewPatientNotCreatedIfInvalidJson() throws QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
 
-        Response response = this.component.updatePatient("[]", this.eid, UPDATE);
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
-        verify(this.logger).debug("Creating patient record with external ID [{}]", this.eid);
+        Response response = this.component.updatePatient("[]", EID, UPDATE);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
         verify(this.repository, never()).create();
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
@@ -261,15 +269,15 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void updatePatientNotFoundNewPatientNotCreatedIfUserDoesNotHaveEditRights() throws QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
         when(this.access.hasAccess(eq(Right.EDIT), eq(this.userReference), any(EntityReference.class)))
             .thenReturn(false);
 
-        Response response = this.component.updatePatient("{}", this.eid, UPDATE);
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
-        verify(this.logger).debug("Creating patient record with external ID [{}]", this.eid);
+        Response response = this.component.updatePatient(EMPTY_JSON, EID, UPDATE);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
         verify(this.logger).error("Edit access denied to user [{}].", this.user);
         verify(this.repository, never()).create();
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
@@ -279,18 +287,18 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void updatePatientNotFoundNewPatientSpecifiesIdInJson() throws QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
 
-        Response response = this.component.updatePatient("{\"external_id\":\"abc\"}", this.eid, UPDATE);
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
-        verify(this.logger).debug("Creating patient record with external ID [{}]", this.eid);
+        Response response = this.component.updatePatient("{\"external_id\":\"abc\"}", EID, UPDATE);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
 
         ArgumentCaptor<JSONObject> json = ArgumentCaptor.forClass(JSONObject.class);
         verify(this.patient).updateFromJSON(json.capture());
-        assertEquals("abc", json.getValue().optString("external_id"));
+        assertEquals("abc", json.getValue().optString(EXTERNAL_ID));
         assertEquals(1, json.getValue().length());
     }
 
@@ -298,18 +306,18 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void updatePatientNotFoundNewPatientNoIdInJson() throws QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
 
-        Response response = this.component.updatePatient("{}", this.eid, UPDATE);
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
-        verify(this.logger).debug("Creating patient record with external ID [{}]", this.eid);
+        Response response = this.component.updatePatient(EMPTY_JSON, EID, UPDATE);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
 
         ArgumentCaptor<JSONObject> json = ArgumentCaptor.forClass(JSONObject.class);
         verify(this.patient).updateFromJSON(json.capture());
-        assertEquals("eid", json.getValue().optString("external_id"));
+        assertEquals(EID, json.getValue().optString(EXTERNAL_ID));
         assertEquals(1, json.getValue().length());
     }
 
@@ -318,7 +326,7 @@ public class DefaultPatientByExternalIdResourceImplTest
     {
         when(this.access.hasAccess(Right.EDIT, this.userReference, this.patientReference)).thenReturn(false);
 
-        Response response = this.component.updatePatient("json", this.eid, UPDATE);
+        Response response = this.component.updatePatient("json", EID, UPDATE);
         verify(this.logger).debug("Edit access denied to user [{}] on patient record [{}]", null, this.patient.getId());
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
 
@@ -327,7 +335,7 @@ public class DefaultPatientByExternalIdResourceImplTest
     @Test(expected = WebApplicationException.class)
     public void updatePatientWrongJSONId() throws ComponentLookupException
     {
-        this.component.updatePatient("{\"id\":\"notid\"}", "eid", UPDATE);
+        this.component.updatePatient("{\"id\":\"notid\"}", EID, UPDATE);
     }
 
     @Test(expected = WebApplicationException.class)
@@ -336,17 +344,17 @@ public class DefaultPatientByExternalIdResourceImplTest
         doThrow(Exception.class).when(this.patient).updateFromJSON(Matchers.any(JSONObject.class), Matchers.any(
             PatientWritePolicy.class));
 
-        this.component.updatePatient("{\"id\":\"id\"}", "eid", UPDATE);
+        this.component.updatePatient("{\"id\":\"id\"}", EID, UPDATE);
         verify(this.logger).debug("Failed to update patient [{}] from JSON: {}. Source JSON was: {}",
-            this.id, "{\"id\":\"id\"}");
+            ID, "{\"id\":\"id\"}");
     }
 
     @Test
     public void updatePatientReturnsNoContentResponse() throws ComponentLookupException
     {
         String json = "{\"id\":\"id\"}";
-        Response response = this.component.updatePatient(json, this.eid, UPDATE);
-        verify(this.logger).debug("Updating patient record with external ID [{}] via REST with JSON: {}", this.eid,
+        Response response = this.component.updatePatient(json, EID, UPDATE);
+        verify(this.logger).debug("Updating patient record with external ID [{}] via REST with JSON: {}", EID,
             json);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
@@ -355,13 +363,13 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void deletePatientReturnsNotFoundStatus() throws QueryException
     {
         Query query = mock(DefaultQuery.class);
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
         when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
         when(query.execute()).thenReturn(new ArrayList<>());
 
-        Response response = this.component.deletePatient(this.eid);
+        Response response = this.component.deletePatient(EID);
 
-        verify(this.logger).debug("No patient record with external ID [{}] exists yet", this.eid);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
     }
 
@@ -370,7 +378,7 @@ public class DefaultPatientByExternalIdResourceImplTest
     {
         when(this.access.hasAccess(Right.DELETE, this.userReference, this.patientReference)).thenReturn(false);
 
-        Response response = this.component.deletePatient(this.eid);
+        Response response = this.component.deletePatient(EID);
 
         verify(this.logger).debug("Delete access denied to user [{}] on patient record [{}]", this.user,
             this.patient.getId());
@@ -381,12 +389,12 @@ public class DefaultPatientByExternalIdResourceImplTest
     public void deletePatientCatchesException() throws WebApplicationException
     {
         doThrow(Exception.class).when(this.repository).delete(this.patient);
-        when(this.repository.getByName(this.eid)).thenReturn(this.patient);
+        when(this.repository.getByName(EID)).thenReturn(this.patient);
         when(this.access.hasAccess(Right.DELETE, null, null)).thenReturn(true);
 
         WebApplicationException ex = null;
         try {
-            this.component.deletePatient(this.eid);
+            this.component.deletePatient(EID);
         } catch (WebApplicationException temp) {
             ex = temp;
         }
@@ -394,17 +402,17 @@ public class DefaultPatientByExternalIdResourceImplTest
         assertNotNull("deletePatient did not throw a WebApplicationException as expected "
             + "when catching an Exception", ex);
         assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), ex.getResponse().getStatus());
-        verify(this.logger).warn(eq("Failed to delete patient record with external id [{}]: {}"), eq(this.eid),
+        verify(this.logger).warn(eq("Failed to delete patient record with external id [{}]: {}"), eq(EID),
             anyString());
     }
 
     @Test
     public void deletePatientReturnsNoContentResponse()
     {
-        Response response = this.component.deletePatient(this.eid);
+        Response response = this.component.deletePatient(EID);
 
         verify(this.repository).delete(this.patient);
-        verify(this.logger).debug("Deleting patient record with external ID [{}] via REST", this.eid);
+        verify(this.logger).debug("Deleting patient record with external ID [{}] via REST", EID);
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 
@@ -416,18 +424,18 @@ public class DefaultPatientByExternalIdResourceImplTest
             .createQuery("where doc.object(PhenoTips.PatientClass).external_id = :eid", Query.XWQL);
 
         List<String> results = new ArrayList<>();
-        results.add(this.eid);
-        results.add(this.eid);
+        results.add(EID);
+        results.add(EID);
         doReturn(results).when(q).execute();
 
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
 
-        Response responseGet = this.component.getPatient(this.eid);
-        Response responseUpdate = this.component.updatePatient(this.eid, this.eid, UPDATE);
-        Response responseDelete = this.component.deletePatient(this.eid);
+        Response responseGet = this.component.getPatient(EID);
+        Response responseUpdate = this.component.updatePatient(EID, EID, UPDATE);
+        Response responseDelete = this.component.deletePatient(EID);
 
         verify(this.logger, times(3)).debug("Multiple patient records ({}) with external ID [{}]: {}",
-            2, this.eid, results);
+            2, EID, results);
         verify(this.factory, times(3)).createAlternatives(anyListOf(String.class), eq(this.uriInfo));
         assertEquals(300, responseGet.getStatus());
         assertEquals(300, responseUpdate.getStatus());
@@ -440,15 +448,129 @@ public class DefaultPatientByExternalIdResourceImplTest
         doThrow(QueryException.class).when(this.qm)
             .createQuery("where doc.object(PhenoTips.PatientClass).external_id = :eid", Query.XWQL);
 
-        when(this.repository.getByName(this.eid)).thenReturn(null);
+        when(this.repository.getByName(EID)).thenReturn(null);
 
-        Response responseGet = this.component.getPatient(this.eid);
-        Response responseUpdate = this.component.updatePatient("{}", this.eid, UPDATE);
-        Response responseDelete = this.component.deletePatient(this.eid);
+        Response responseGet = this.component.getPatient(EID);
+        Response responseUpdate = this.component.updatePatient(EMPTY_JSON, EID, UPDATE);
+        Response responseDelete = this.component.deletePatient(EID);
 
-        verify(this.logger, times(3)).warn("Failed to retrieve patient with external id [{}]: {}", this.eid, null);
+        verify(this.logger, times(3)).warn("Failed to retrieve patient with external id [{}]: {}", EID, null);
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), responseGet.getStatus());
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), responseUpdate.getStatus());
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), responseDelete.getStatus());
+    }
+
+    // ----------------------------Patch Patient Tests-----------------------------
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientWithNullJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient(null, EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientWithEmptyJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient(StringUtils.EMPTY, EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientWithBlankJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient(StringUtils.SPACE, EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test
+    public void patchPatientNoPatientWithSpecifiedEidExistsResultsPatientBeingCreated() throws QueryException
+    {
+        when(this.repository.get(PATIENT_ID)).thenReturn(null);
+        final Query query = mock(Query.class);
+        when(this.qm.createQuery(anyString(), eq(Query.XWQL))).thenReturn(query);
+        when(query.execute()).thenReturn(Collections.emptyList());
+        final Response response = this.component.patchPatient(EMPTY_JSON, PATIENT_ID);
+        Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        verify(this.repository, times(1)).create();
+    }
+
+    @Test
+    public void patchPatientManyPatientsWithSpecifiedEidExistResultsInCorrectResponse() throws QueryException
+    {
+        when(this.repository.get(PATIENT_ID)).thenReturn(null);
+        final Query query = mock(Query.class);
+        when(this.qm.createQuery(anyString(), eq(Query.XWQL))).thenReturn(query);
+        when(query.execute()).thenReturn(Arrays.asList("one", "two"));
+        final Response response = this.component.patchPatient(EMPTY_JSON, PATIENT_ID);
+        Assert.assertEquals(300, response.getStatus());
+        verify(this.repository, never()).create();
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientUserHasNoEditAccessThrowsWebApplicationException()
+    {
+        try {
+            when(this.access.hasAccess(Right.EDIT, this.userReference, this.patientReference)).thenReturn(false);
+            this.component.patchPatient(EMPTY_JSON, EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientInvalidJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient("[]", EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientIdFromJsonAndRetrievedPatientIdConflictThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient("{\"id\":\"wrong\"}", EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.CONFLICT.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientUpdatingPatientFromJsonFailsResultsInWebApplicationException()
+    {
+        try {
+            doThrow(new RuntimeException()).when(this.patient).updateFromJSON(any(JSONObject.class),
+                eq(PatientWritePolicy.MERGE));
+            this.component.patchPatient(EMPTY_JSON, EID);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test
+    public void patchPatientUpdatesPatientSuccessfully()
+    {
+        final Response response = this.component.patchPatient(EMPTY_JSON, EID);
+        verify(this.patient, times(1)).updateFromJSON(any(JSONObject.class), eq(PatientWritePolicy.MERGE));
+        Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
     }
 }


### PR DESCRIPTION
Depends on #2348. First five commits are from that pull request.

For testing:

* Update patient by ID:
  - update
```curl -X POST -u <username>:<password> -d '<json>' http://localhost:<port>/rest/patients/<id>?method=PUT -H "Content-Type:application/json"```
  - merge
``` curl -X POST -u <username>:<password> -d '<json>' http://localhost:<port>/rest/patients/<id>?method=PATCH -H "Content-Type:application/json"```

* Update patient by external ID:
  - update
```curl -X POST -u <username>:<password> -d '<json>' http://localhost:<port>/rest/patients/eid/<e_id>?method=PUT -H "Content-Type:application/json"```
  - merge
``` curl -X POST -u <username>:<password> -d '<json>' http://localhost:<port>/rest/patients/eid/<e_id>?method=PATCH -H "Content-Type:application/json"```