### PR TITLE
PT-3278: Export doesn't take into account the filters for genes and for clinical diagnosis

### DIFF
--- a/components/navigation/ui/src/main/resources/PhenoTips/LiveTableMacros.xml
+++ b/components/navigation/ui/src/main/resources/PhenoTips/LiveTableMacros.xml
@@ -447,7 +447,7 @@
     ##
     ## Document authors, exact match if the filter value contains a wiki or a space name, substring matches otherwise
     #elseif($colname == 'doc.creator' || $colname == 'doc.author')
-      #foreach ($filterValue in $request.getParameterValues($colname))
+      #foreach ($filterValue in $filterValueList)
         #if ($foreach.index == 0)
           #set ($whereSql = "${whereSql} and (")
         #else


### PR DESCRIPTION
Fixed regression: filtering by referrer or last author in the export dialog doesn't work anymore.