### PR TITLE
PT-3320: Pedigree node hover boxes do not fade out when they should in some cases

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/editor.css
+++ b/components/pedigree/resources/src/main/resources/pedigree/editor.css
@@ -174,8 +174,7 @@ input[type="radio"] {
  * Zoom
  */
 .view-controls-zoom {
-  width: 60px;
-  left: 0;
+  left: 18px;
   top: 70px;
   position: absolute;
   text-align: center;
@@ -191,6 +190,7 @@ input[type="radio"] {
   width: 4px;
   height: 200px;
   position: relative;
+  cursor: pointer;
 }
 .view-controls-zoom .zoom-button {
   cursor: pointer;

--- a/components/pedigree/resources/src/main/resources/pedigree/view/abstractHoverbox.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/abstractHoverbox.js
@@ -679,11 +679,17 @@ define([
                 var click = editor.getWorkspace().divToCanvas(div.x,div.y);
 
                 // only activate "do not hide" check if mouse is still on top of SVG, and not on top of main menu or other windows
+                //
+                // note: some browsers incorrectly report the svgarea's .bottom and .right positions,
+                //       so need to use some adjustment there; the value "3" is derived empirically
                 var svgarea = document.getElementById("work-area").getBoundingClientRect();
-                if (y > svgarea.top && x > svgarea.left && y < svgarea.bottom && x < svgarea.right) {
-                    if (click.x > hoverarea.x && click.x < hoverarea.x2 &&
-                        click.y > hoverarea.y && click.y < hoverarea.y2) {
-                        return;
+                if (y > svgarea.top && x > svgarea.left && y < svgarea.bottom - 3 && x < svgarea.right - 3) {
+                    if (click.x > Math.ceil(hoverarea.x) && click.x < Math.floor(hoverarea.x2) &&
+                        click.y > Math.ceil(hoverarea.y) && click.y < Math.floor(hoverarea.y2)) {
+                        // zoom control behaves in a special way in terms of hoverboxes, so need to treat is specially
+                        if ("relatedTarget" in event && !event.relatedTarget.hasClassName("view-controls-zoom") && !event.relatedTarget.hasClassName("zoom-button")) {
+                            return;
+                        }
                     }
                 }
             }

--- a/components/pedigree/resources/src/main/resources/pedigree/view/abstractHoverbox.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/abstractHoverbox.js
@@ -670,7 +670,7 @@ define([
         animateHideHoverZone: function(event, x, y) {
             if (editor.getView().getCurrentDraggable() !== null) return; // do not hide when dragging
 
-            if (event) {
+            if (event && event.relatedTarget && event.relatedTarget.id != 'canvas') {
                 // hoverbox has a lot of internal elements, which trigger the event. To avoid reacting to those,
                 // the pointer position is computed i nterms of raw {x,y} coordinates, and hoverbox is hidden only if mouse
                 // is outside the hoverbox
@@ -683,11 +683,11 @@ define([
                 // note: some browsers incorrectly report the svgarea's .bottom and .right positions,
                 //       so need to use some adjustment there; the value "3" is derived empirically
                 var svgarea = document.getElementById("work-area").getBoundingClientRect();
-                if (y > svgarea.top && x > svgarea.left && y < svgarea.bottom - 3 && x < svgarea.right - 3) {
+                if (y > svgarea.top && x > svgarea.left && y < svgarea.bottom && x < svgarea.right) {
                     if (click.x > Math.ceil(hoverarea.x) && click.x < Math.floor(hoverarea.x2) &&
                         click.y > Math.ceil(hoverarea.y) && click.y < Math.floor(hoverarea.y2)) {
                         // zoom control behaves in a special way in terms of hoverboxes, so need to treat is specially
-                        if ("relatedTarget" in event && !event.relatedTarget.hasClassName("view-controls-zoom") && !event.relatedTarget.hasClassName("zoom-button")) {
+                        if (!event.relatedTarget.hasClassName || !event.relatedTarget.hasClassName("view-controls-zoom") && !event.relatedTarget.hasClassName("zoom-button")) {
                             return;
                         }
                     }


### PR DESCRIPTION
Attempt to fix the "exit through the bottom doesn't hide the hoverbox" bug. The "exist through pan controls doesn't hide the hoverbox" bug is still there.

*This is on top of the PT-3320 branch*.