### PR TITLE
PT-3357: In pedigree editor do not show A&W options on hoverboxes for patients which are read-only for current user

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/personHoverbox.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/personHoverbox.js
@@ -156,8 +156,11 @@ define([
             $super();
 
             this.generateMenuBtn();
-            if (this.getNode().getLifeStatus() == "alive" || this.getNode().getLifeStatus() == "deceased") {
-                this.generateAliveWell();
+
+            if (editor.getPatientAccessPermissions(this.getNode().getPhenotipsPatientId()).hasEdit) {
+                if (this.getNode().getLifeStatus() == "alive" || this.getNode().getLifeStatus() == "deceased") {
+                    this.generateAliveWell();
+                }
             }
 
             this._updateHoverBoxHeight();


### PR DESCRIPTION
@sashaandjic please test