### PR TITLE
PT-3376: Live tables: replace "Reported by" column with "Owner"

### DIFF
--- a/components/navigation/ui/src/main/resources/data/WebHome.xml
+++ b/components/navigation/ui/src/main/resources/data/WebHome.xml
@@ -265,7 +265,7 @@ $xwiki.ssx.use('PhenoTips.DBConfigurationClass')##
       <livetableColumns>
         <value>doc.name</value>
         <value>external_id</value>
-        <value>doc.creator</value>
+        <value>owner/PhenoTips.OwnerClass</value>
         <value>doc.author</value>
         <value>doc.creationDate</value>
         <value>doc.date</value>


### PR DESCRIPTION
Changed the default columns. Unfortunately, until we implement support for column reordering in administration, the owner column may end up in a different position when an Admin modifies the livetable columns in a running PhenoTips.