### PR TITLE
PT-3429: Do not propagate click events beyond the modal popup

### DIFF
--- a/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
@@ -2073,7 +2073,7 @@ widgets.ModalPopup = Class.create({
 
     // Stop the propagation of mouse events beyond the dialog element to prevent unwanted interaction with anything in the back
     var _this = this;
-    ['mousedown', 'mouseup', 'click'].each(function(eventName) {
+    ['mousedown', 'click'].each(function(eventName) {
       _this.dialog.observe(eventName, function(event) {
         event.stop();
       });

--- a/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/Widgets.xml
@@ -2070,6 +2070,14 @@ widgets.ModalPopup = Class.create({
        Event.observe(window, eventName, __enableUpdateScreenSize);
     }.bind(this));
     Event.observe(document, 'ms:popup:content-updated', __enableUpdateScreenSize);
+
+    // Stop the propagation of mouse events beyond the dialog element to prevent unwanted interaction with anything in the back
+    var _this = this;
+    ['mousedown', 'mouseup', 'click'].each(function(eventName) {
+      _this.dialog.observe(eventName, function(event) {
+        event.stop();
+      });
+    });
   },
   positionDialog : function() {
     switch(this.options.verticalPosition) {


### PR DESCRIPTION
How to test:
- Open a patient record
- Go to phenotyping
- Click on an (i) button for a predefined phenotype -> Tooltip opens
- Click on "Browse related terms" -> Ontology browser opens
- Click _anywhere_ in the ontology browser dialog or on the dark screen behind it.

Result before this change: the tooltip disapears
Result after this change: the tooltip remains open

Known side effect: Tooltips from the ontology browser can only be closed by clicking on their x button (or by opening another tooltip, and not by clicking outside.