### PR TITLE
PT-3428: BROWSE RELATED TERMS button does not work in pedigree editor

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/editor.css
+++ b/components/pedigree/resources/src/main/resources/pedigree/editor.css
@@ -772,7 +772,7 @@ li.abnormality:hover {
   padding: 1em 0;
 }
 /* Disable the "browse ontology" button, as ontology browser events are not supported (yet) */
-.tooltip-phenotype-info .term-tools {
+.xHelpButton.phenotype-info + .xTooltip .term-tools {
   display: none;
 }
 .menu-box .field-disorders {


### PR DESCRIPTION
Quick fix: don't show the browse button. It was already hidden for phenotype suggestions.