### PR TITLE
PT-3424: Implement a migrator from auto-generated internal pedigree format

### DIFF
--- a/components/family-studies/migrations/pom.xml
+++ b/components/family-studies/migrations/pom.xml
@@ -117,6 +117,6 @@
   </dependencies>
   <properties>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <coverage.instructionRatio>0.19</coverage.instructionRatio>
+    <coverage.instructionRatio>0.24</coverage.instructionRatio>
   </properties>
 </project>

--- a/components/family-studies/migrations/src/main/java/org/phenotips/studies/family/migrations/R71508PhenoTips3424DataMigration.java
+++ b/components/family-studies/migrations/src/main/java/org/phenotips/studies/family/migrations/R71508PhenoTips3424DataMigration.java
@@ -1,0 +1,360 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+
+package org.phenotips.studies.family.migrations;
+
+import org.phenotips.Constants;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.HibernateException;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
+import com.xpn.xwiki.store.XWikiHibernateStore;
+import com.xpn.xwiki.store.migration.DataMigrationException;
+import com.xpn.xwiki.store.migration.XWikiDBVersion;
+import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
+
+/**
+ * Migrate internal represenation of pedigrees stored in the auto-generated SimpleJSON format.
+ *
+ * @version $Id$
+ * @since 1.4M3
+ */
+@Component
+@Named("R71508-PT-3424")
+@Singleton
+public class R71508PhenoTips3424DataMigration extends AbstractHibernateDataMigration implements
+    HibernateCallback<Object>
+{
+    /**
+     * Pedigree XClass that holds pedigree data (image, structure, etc).
+     */
+    private static final EntityReference PEDIGREE_CLASS_REFERENCE =
+        new EntityReference("PedigreeClass", EntityType.DOCUMENT, Constants.CODE_SPACE_REFERENCE);
+
+    private static final String PEDIGREECLASS_JSONDATA_KEY = "data";
+
+    private static final String SIMPLE_JSON_DATA_KEY = "data";
+
+    private static final String SIMPLE_JSON_PATIENT_LINK_KEY = "phenotipsId";
+
+    private static final String SIMPLE_JSON_EXTERNALID_KEY = "externalId";
+
+    private static final String PEDIGREE_VERSION_KEY = "JSON_version";
+
+    private static final String PEDIGREE_VERSION_VALUE = "1.0";
+
+    private static final String PEDIGREE_PROBAND_KEY = "proband";
+
+    private static final String PEDIGREE_MEMBERS_KEY = "members";
+
+    private static final String PEDIGREE_RELATIONS_KEY = "relationships";
+
+    /** Logging helper object. */
+    @Inject
+    private Logger logger;
+
+    /** Resolves unprefixed document names to the current wiki. */
+    @Inject
+    @Named("current")
+    private DocumentReferenceResolver<String> resolver;
+
+    /** Serializes the class name without the wiki prefix, to be used in the database query. */
+    @Inject
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> serializer;
+
+    @Override
+    public String getDescription()
+    {
+        return "Update pedigree data to new format";
+    }
+
+    @Override
+    public XWikiDBVersion getVersion()
+    {
+        return new XWikiDBVersion(71508);
+    }
+
+    @Override
+    public void hibernateMigrate() throws DataMigrationException, XWikiException
+    {
+        getStore().executeWrite(getXWikiContext(), this);
+    }
+
+    @Override
+    public Object doInHibernate(Session session) throws HibernateException, XWikiException
+    {
+        XWikiContext context = getXWikiContext();
+        XWiki xwiki = context.getWiki();
+
+        // Select all families
+        Query q = session.createQuery("select distinct o.name from BaseObject o where o.className = '"
+            + this.serializer.serialize(PEDIGREE_CLASS_REFERENCE)
+            + "' and o.name <> 'PhenoTips.FamilyTemplate'");
+
+        @SuppressWarnings("unchecked")
+        List<String> docs = q.list();
+
+        this.logger.debug("Found {} documents", docs.size());
+
+        for (String docName : docs) {
+            XWikiDocument xDocument;
+            BaseObject pedigreeXObject;
+
+            try {
+                xDocument = xwiki.getDocument(this.resolver.resolve(docName), context);
+                if (xDocument == null) {
+                    continue;
+                }
+
+                pedigreeXObject = xDocument.getXObject(PEDIGREE_CLASS_REFERENCE);
+                if (pedigreeXObject == null) {
+                    continue;
+                }
+            } catch (Exception e) {
+                this.logger.error("Error checking pedigree data for document {}: [{}]",
+                        docName, e.getMessage());
+                continue;
+            }
+
+            try {
+                this.logger.debug("Updating pedigree for document {}.", docName);
+
+                if (!this.updatePedigree(pedigreeXObject, context, docName)) {
+                    continue;
+                }
+
+                xDocument.setComment(this.getDescription());
+                xDocument.setMinorEdit(true);
+
+            } catch (Exception e) {
+                this.logger.error("Error updating pedigree data format for document {}: [{}]",
+                        docName, e.getMessage());
+                continue;
+            }
+
+            try {
+                // There's a bug in XWiki which prevents saving an object in the same session that it was loaded,
+                // so we must clear the session cache first.
+                session.clear();
+                ((XWikiHibernateStore) getStore()).saveXWikiDoc(xDocument, context, false);
+                session.flush();
+            } catch (DataMigrationException e) {
+                this.logger.error("Error when saving XWiki document {}: [{}]", docName, e.getMessage());
+            }
+
+        }
+        return null;
+    }
+
+    private boolean updatePedigree(BaseObject pedigreeXObject, XWikiContext context, String docName)
+    {
+        String oldPedigreeAsText = pedigreeXObject.getStringValue(PEDIGREECLASS_JSONDATA_KEY);
+        if (!StringUtils.isEmpty(oldPedigreeAsText)) {
+            if (pedigreeIsInSimpleJSONFormat(oldPedigreeAsText)) {
+                String convertedPedigree = this.convertPedigreeData(oldPedigreeAsText);
+                pedigreeXObject.set(PEDIGREECLASS_JSONDATA_KEY, convertedPedigree, context);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean pedigreeIsInSimpleJSONFormat(String pedigreeAsText)
+    {
+        JSONObject pedigreeJSON = new JSONObject(pedigreeAsText);
+        return (pedigreeJSON.optJSONArray(SIMPLE_JSON_DATA_KEY) != null);
+    }
+
+    // represents all data known about a particular relationship
+    private static class Relationship
+    {
+        private Set<Integer> parents = new HashSet<>();
+        private Set<Integer> children = new HashSet<>();
+        private final String id;
+
+        Relationship(Integer parentID1, Integer parentID2)
+        {
+            this.id = "rel_" + Math.min(parentID1, parentID2) + "_" + Math.max(parentID1, parentID2);
+
+            if (parentID1 >= 0) {
+                this.parents.add(parentID1);
+            }
+            if (parentID2 >= 0) {
+                this.parents.add(parentID2);
+            }
+        }
+
+        public String getCoupleId()
+        {
+            return this.id;
+        }
+
+        public Set<Integer> getParents()
+        {
+            return this.parents;
+        }
+
+        public Set<Integer> getChildren()
+        {
+            return this.children;
+        }
+
+        public void addChild(Integer id)
+        {
+            this.children.add(id);
+        }
+    }
+
+    private String convertPedigreeData(String oldFormatData)
+    {
+        JSONObject oldPedigreeData = new JSONObject(oldFormatData);
+
+        this.logger.debug("Old pedigree: [{}]", oldPedigreeData.toString());
+
+        // create a sceleton JSON with all data structures present but blank
+        JSONObject newPedigree = this.createBlankNewPedigreeJSON();
+
+        // Note1: the assumption is that pedigree is consistent and correct, if a required key
+        //        is missing an exception will be thrown (e.g. by getJSONArray()), which is expected
+
+        JSONArray oldData = oldPedigreeData.getJSONArray(SIMPLE_JSON_DATA_KEY);
+
+        // 1. process all persons nodes, collecting data about relationships
+
+        // for each pair of parents/partners (represented by an integer "combination ID") -> a relationship object
+        Map<String, Relationship> relationships = new HashMap<>();
+
+        for (Object node : oldData) {
+            JSONObject nodeObj = (JSONObject) node;
+            this.processPerson(nodeObj, newPedigree, relationships);
+        }
+
+        // 2. process all relationships, now that we know all the partners
+        int relationshipNumber = 1;
+        for (Relationship relationship : relationships.values()) {
+            this.processRelationship(relationshipNumber++, relationship, newPedigree);
+        }
+
+        this.logger.debug("Converted pedigree: [{}]", newPedigree.toString());
+
+        return newPedigree.toString();
+    }
+
+    private JSONObject createBlankNewPedigreeJSON()
+    {
+        JSONObject newPedigree = new JSONObject();
+
+        newPedigree.put(PEDIGREE_VERSION_KEY, PEDIGREE_VERSION_VALUE);
+
+        newPedigree.put(PEDIGREE_MEMBERS_KEY, new JSONArray());
+
+        newPedigree.put(PEDIGREE_RELATIONS_KEY, new JSONArray());
+
+        return newPedigree;
+    }
+
+    private void processPerson(JSONObject oldJSON, JSONObject newPedigree, Map<String, Relationship> relationships)
+    {
+        Integer nodeId = oldJSON.getInt("id");
+
+        JSONObject newObj = new JSONObject();
+        newObj.put("id", nodeId);
+
+        // convert properties into old phenotips properties
+        JSONObject properties = new JSONObject();
+        properties.put("gender", oldJSON.optString("sex", "U"));
+        if (oldJSON.has(SIMPLE_JSON_PATIENT_LINK_KEY)) {
+            properties.put("phenotipsId", oldJSON.getString(SIMPLE_JSON_PATIENT_LINK_KEY));
+        }
+        if (oldJSON.has(SIMPLE_JSON_EXTERNALID_KEY)) {
+            properties.put("externalID", oldJSON.getString(SIMPLE_JSON_EXTERNALID_KEY));
+        }
+
+        newObj.put("pedigreeProperties", properties);
+
+        // store migrated data for this person
+        newPedigree.getJSONArray(PEDIGREE_MEMBERS_KEY).put(newObj);
+
+        // if parents are known: create or update the producing relationship
+        if (oldJSON.has("mother") || oldJSON.has("father")) {
+            Relationship rel = new Relationship(oldJSON.optInt("mother", -1), oldJSON.optInt("father", -1));
+            if (relationships.containsKey(rel.getCoupleId())) {
+                rel = relationships.get(rel.getCoupleId());
+            } else {
+                relationships.put(rel.getCoupleId(), rel);
+            }
+            rel.addChild(nodeId);
+        }
+
+        if (oldJSON.optBoolean("proband", false)) {
+            newPedigree.put(PEDIGREE_PROBAND_KEY, nodeId);
+        }
+    }
+
+    private void processRelationship(int relationshipNumber, Relationship relationship, JSONObject newPedigree)
+    {
+        JSONObject newObj = new JSONObject();
+        newObj.put("id", relationshipNumber);
+
+        newObj.put("members", relationship.getParents());
+
+        newObj.put("children", this.createRelationshipChildrenArray(relationship.getChildren()));
+
+        // store migrated data for this relationship
+        newPedigree.getJSONArray(PEDIGREE_RELATIONS_KEY).put(newObj);
+    }
+
+    private JSONArray createRelationshipChildrenArray(Set<Integer> childIDs)
+    {
+        JSONArray children = new JSONArray();
+        for (Integer childID : childIDs) {
+            JSONObject nextChild = new JSONObject();
+            nextChild.put("id", childID);
+            children.put(nextChild);
+        }
+        return children;
+    }
+}

--- a/components/family-studies/migrations/src/main/resources/META-INF/components.txt
+++ b/components/family-studies/migrations/src/main/resources/META-INF/components.txt
@@ -7,4 +7,5 @@ org.phenotips.studies.family.migrations.R71503PhenoTips1393DataMigration
 org.phenotips.studies.family.migrations.R71505PhenoTips3402DataMigration
 org.phenotips.studies.family.migrations.R71506PhenoTips3292DataMigration
 org.phenotips.studies.family.migrations.R71507PhenoTips3423DataMigration
+org.phenotips.studies.family.migrations.R71508PhenoTips3424DataMigration
 

--- a/components/family-studies/migrations/src/test/java/org/phenotips/studies/family/migrations/R71507PhenoTips3423DataMigrationTest.java
+++ b/components/family-studies/migrations/src/test/java/org/phenotips/studies/family/migrations/R71507PhenoTips3423DataMigrationTest.java
@@ -67,6 +67,9 @@ public class R71507PhenoTips3423DataMigrationTest
 
     private static final String ERROR_UPDATING_DATA = "Error updating pedigree data format for document {}: [{}]";
 
+    private static final String WARNING_SIMPLE_JSON =
+            "Skipping conversion for family [{}] - pedigree is in SimpleJSON format";
+
     private static final String SERIALIZED_ENTITY = "serialized_entity";
 
     private static final String WIKI_ID = "wikiID";
@@ -116,6 +119,10 @@ public class R71507PhenoTips3423DataMigrationTest
         + "`:{},`cancers`:{},`candidateGenes`:{},`carrierGenes`:{}}}},`ranks`:[5,4,3,3,3,2,1,1,1,5,6,7,5,4,3,2,1],`pr"
         + "obandNodeID`:0,`JSON_version`:`1.0`,`positions`:[5,5,5,17,-7,17,17,43,5,20,20,20,31,31,31,31,31],`order`:["
         + "[],[8,6,16,7],[5,15],[4,2,3,14],[1,13],[0,9,12],[10],[11]]}").replace('`', '"');
+
+    private static final String PEDIGREE_SIMPLE_JSON_DATA = ("{`data`:[{`id`:2},{`id`:3},{`mother`:`3`,`phenotipsId`:"
+        + "`P0000001`,`sex`:`U`,`father`:`2`,`id`:1,`proband`:true},{`mother`:3,`phenotipsId`:`P0000003`,`father`:2,`"
+        + "id`:4},{`id`:5},{`mother`:5,`phenotipsId`:`P0000002`,`father`:1,`id`:6}]}").replace('`', '"');
 
     private static final String PEDIGREE_1_MIGRATED_DATA = ("{`layout`:{`relationships`:{`2`:{`x`:5,`order`:1}},`membe"
         + "rs`:{`0`:{`generation`:3,`x`:5,`order`:0},`3`:{`generation`:1,`x`:17,`order`:2},`4`:{`generation`:1,`x`:-7"
@@ -319,6 +326,23 @@ public class R71507PhenoTips3423DataMigrationTest
         verify(this.pedigreeBaseObject1, times(1)).getStringValue(PEDIGREECLASS_JSONDATA_KEY);
 
         verify(this.logger, times(1)).error(eq(ERROR_UPDATING_DATA), eq(FAMILY_1), any());
+        verifyNoMoreInteractions(this.xwiki, this.xDocument1, this.pedigreeBaseObject1);
+    }
+
+    @Test
+    public void doInHibernateDoesNothingWhenPedigreeIsInSimpleJSONFormat() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+        when(this.pedigreeBaseObject1.getStringValue(PEDIGREECLASS_JSONDATA_KEY))
+            .thenReturn(PEDIGREE_SIMPLE_JSON_DATA);
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verify(this.xDocument1, times(1)).getXObject(any(EntityReference.class));
+        verify(this.pedigreeBaseObject1, times(1)).getStringValue(PEDIGREECLASS_JSONDATA_KEY);
+
+        verify(this.logger, times(1)).warn(eq(WARNING_SIMPLE_JSON), eq(FAMILY_1));
         verifyNoMoreInteractions(this.xwiki, this.xDocument1, this.pedigreeBaseObject1);
     }
 

--- a/components/family-studies/migrations/src/test/java/org/phenotips/studies/family/migrations/R71508PhenoTips3424DataMigrationTest.java
+++ b/components/family-studies/migrations/src/test/java/org/phenotips/studies/family/migrations/R71508PhenoTips3424DataMigrationTest.java
@@ -1,0 +1,250 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.studies.family.migrations;
+
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+import java.util.Collections;
+
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.store.XWikiHibernateStore;
+import com.xpn.xwiki.store.XWikiStoreInterface;
+import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link R71507henoTips3423DataMigration}.
+ */
+public class R71508PhenoTips3424DataMigrationTest
+{
+    private static final String ERROR_UPDATING_DATA = "Error updating pedigree data format for document {}: [{}]";
+
+    private static final String SERIALIZED_ENTITY = "serialized_entity";
+
+    private static final String WIKI_ID = "wikiID";
+
+    private static final String PEDIGREECLASS_JSONDATA_KEY = "data";
+
+    private static final String FAMILY_1 = "family1";
+
+    // a sample pedigree in the auto-generated format created by old family-studies data conversion
+    private static final String PEDIGREE_SIMPLE_JSON_DATA = ("{`data`:[{`id`:2},{`id`:3},{`mother`:`3`,`phenotipsId`:"
+        + "`P0000001`,`sex`:`U`,`father`:`2`,`id`:1},{`mother`:3,`proband`:true,`phenotipsId`:`P0000003`,`father`:2,`"
+        + "id`:4},{`id`:5},{`mother`:5,`phenotipsId`:`P0000002`,`father`:1,`id`:6}]}").replace('`', '"');
+
+    private static final String PEDIGREE_MIGRATED_DATA = ("{`relationships`:[{`children`:[{`id`:6}],`members`:[1,5],`"
+        + "id`:1},{`children`:[{`id`:1},{`id`:4}],`members`:[2,3],`id`:2}],`members`:[{`id`:2,`pedigreeProperties`:{`"
+        + "gender`:`U`}},{`id`:3,`pedigreeProperties`:{`gender`:`U`}},{`id`:1,`pedigreeProperties`:{`gender`:`U`,`phe"
+        + "notipsId`:`P0000001`}},{`id`:4,`pedigreeProperties`:{`gender`:`U`,`phenotipsId`:`P0000003`}},{`id`:5,`pedi"
+        + "greeProperties`:{`gender`:`U`}},{`id`:6,`pedigreeProperties`:{`gender`:`U`,`phenotipsId`:`P0000002`}}],`JS"
+        + "ON_version`:`1.0`,`proband`:4}").replace('`', '"');
+
+    private static final String PEDIGREE_NEW_FORMAT_DATA = PEDIGREE_MIGRATED_DATA;
+
+    @Rule
+    public MockitoComponentMockingRule<HibernateDataMigration> mocker =
+        new MockitoComponentMockingRule<>(R71508PhenoTips3424DataMigration.class, HibernateDataMigration.class,
+            "R71508-PT-3424");
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private XWikiContext context;
+
+    @Mock
+    private XWiki xwiki;
+
+    @Mock
+    private Query query;
+
+    @Mock
+    private DocumentReference documentReference1;
+
+    @Mock
+    private BaseObject pedigreeBaseObject1;
+
+    @Mock
+    private XWikiDocument xDocument1;
+
+    @Mock
+    private XWikiHibernateStore store;
+
+    private R71508PhenoTips3424DataMigration component;
+
+    private Logger logger;
+
+    private ComponentManager componentManager;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        MockitoAnnotations.initMocks(this);
+
+        this.mocker.registerMockComponent(ComponentManager.class);
+        this.componentManager = this.mocker.getInstance(ComponentManager.class);
+        when(this.componentManager.getInstance(XWikiStoreInterface.class, "hibernate")).thenReturn(this.store);
+
+        this.component = (R71508PhenoTips3424DataMigration) this.mocker.getComponentUnderTest();
+        this.logger = this.mocker.getMockedLogger();
+
+        final EntityReferenceSerializer<String> serializer =
+            this.mocker.getInstance(EntityReferenceSerializer.TYPE_STRING, "compactwiki");
+        when(serializer.serialize(any(EntityReference.class))).thenReturn(SERIALIZED_ENTITY);
+
+        final Execution execution = this.mocker.getInstance(Execution.class);
+        final ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(execution.getContext()).thenReturn(executionContext);
+        when(executionContext.getProperty(anyString())).thenReturn(this.context);
+        when(this.context.getWiki()).thenReturn(this.xwiki);
+        when(this.context.getWikiId()).thenReturn(WIKI_ID);
+
+        when(this.session.createQuery(anyString())).thenReturn(this.query);
+
+        final DocumentReferenceResolver<String> resolver =
+            this.mocker.getInstance(DocumentReferenceResolver.TYPE_STRING, "current");
+        when(resolver.resolve(FAMILY_1)).thenReturn(this.documentReference1);
+
+        when(this.xwiki.getDocument(this.documentReference1, this.context)).thenReturn(this.xDocument1);
+
+        when(this.xDocument1.getXObject(any(EntityReference.class))).thenReturn(this.pedigreeBaseObject1);
+
+        when(this.pedigreeBaseObject1.getStringValue(PEDIGREECLASS_JSONDATA_KEY)).thenReturn(PEDIGREE_SIMPLE_JSON_DATA);
+    }
+
+    @Test
+    public void doInHibernateDoesNothingWhenFamiliesHaveNoXWikiDocument() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+        when(this.xwiki.getDocument(this.documentReference1, this.context)).thenReturn(null);
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verifyNoMoreInteractions(this.xwiki);
+    }
+
+    @Test
+    public void doInHibernateDoesNothingWhenFamiliesHaveNoPedigreeBaseObjects() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+        when(this.xDocument1.getXObject(any(EntityReference.class))).thenReturn(null);
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verify(this.xDocument1, times(1)).getXObject(any(EntityReference.class));
+
+        verifyNoMoreInteractions(this.xwiki, this.xDocument1);
+    }
+
+    @Test
+    public void doInHibernateDoesNothingWhenFamilyPedigreeHasNullData() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+        when(this.pedigreeBaseObject1.getStringValue(PEDIGREECLASS_JSONDATA_KEY)).thenReturn(null);
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verify(this.xDocument1, times(1)).getXObject(any(EntityReference.class));
+        verify(this.pedigreeBaseObject1, times(1)).getStringValue(PEDIGREECLASS_JSONDATA_KEY);
+        verifyNoMoreInteractions(this.xwiki, this.xDocument1, this.pedigreeBaseObject1);
+    }
+
+    @Test
+    public void doInHibernateDoesNothingWhenFamilyPedigreeHasInvalidData() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+        when(this.pedigreeBaseObject1.getStringValue(PEDIGREECLASS_JSONDATA_KEY)).thenReturn("I'm not JSON");
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verify(this.xDocument1, times(1)).getXObject(any(EntityReference.class));
+        verify(this.pedigreeBaseObject1, times(1)).getStringValue(PEDIGREECLASS_JSONDATA_KEY);
+
+        verify(this.logger, times(1)).error(eq(ERROR_UPDATING_DATA), eq(FAMILY_1), any());
+        verifyNoMoreInteractions(this.xwiki, this.xDocument1, this.pedigreeBaseObject1);
+    }
+
+    @Test
+    public void doInHibernateDoesNothingWhenPedigreeIsAlreadyConverted() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+        when(this.pedigreeBaseObject1.getStringValue(PEDIGREECLASS_JSONDATA_KEY))
+            .thenReturn(PEDIGREE_NEW_FORMAT_DATA);
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verify(this.xDocument1, times(1)).getXObject(any(EntityReference.class));
+        verify(this.pedigreeBaseObject1, times(1)).getStringValue(PEDIGREECLASS_JSONDATA_KEY);
+
+        verifyNoMoreInteractions(this.xwiki, this.xDocument1, this.pedigreeBaseObject1);
+    }
+
+    @Test
+    public void doInHibernateBehavesAsExpectedForSimplePedigree() throws XWikiException
+    {
+        when(this.query.list()).thenReturn(Collections.singletonList(FAMILY_1));
+
+        this.component.doInHibernate(this.session);
+
+        verify(this.xwiki, times(1)).getDocument(any(DocumentReference.class), any(XWikiContext.class));
+        verify(this.xDocument1, times(1)).getXObject(any(EntityReference.class));
+
+        verify(this.pedigreeBaseObject1, times(1)).getStringValue(PEDIGREECLASS_JSONDATA_KEY);
+
+        verify(this.pedigreeBaseObject1, times(1)).set(eq(PEDIGREECLASS_JSONDATA_KEY), eq(PEDIGREE_MIGRATED_DATA),
+            eq(this.context));
+
+        verify(this.xDocument1, times(1)).setComment(this.component.getDescription());
+        verify(this.xDocument1, times(1)).setMinorEdit(true);
+
+        verify(this.store, times(1)).saveXWikiDoc(this.xDocument1, this.context, false);
+    }
+}

--- a/components/pedigree/resources/src/main/resources/pedigree/model/import.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/model/import.js
@@ -91,6 +91,9 @@ define([
             var properties = {};
             if (nextPerson.hasOwnProperty("pedigreeProperties") && typeof nextPerson.pedigreeProperties == 'object') {
                 properties = nextPerson.pedigreeProperties;
+                if (!properties.gender) {
+                    properties.gender = "U";
+                }
             }
 
             var nodeID = newG._addVertex( null, BaseGraph.TYPE.PERSON, properties, {} );


### PR DESCRIPTION
For testing, first need to migrate "old family studies" data, then used migrated pedigrees (which will be in "simple JSON" format, as opposed to "old internal") as input for this migrator

For reviewers: only the last two commits are for this issue, all others are from branches this is based on