### PR TITLE
PT-3285: In pedigree, offer an option to delete unlinked patient records

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/editor.css
+++ b/components/pedigree/resources/src/main/resources/pedigree/editor.css
@@ -100,11 +100,16 @@ input[type="radio"] {
   margin: 0;
 }
 .loading-indicator {
-    background-image: url("$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')");
-    background-position: center;
-    background-repeat: no-repeat;
-    height: 100px;
-    width: 200px;
+  background-image: url("$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')");
+  background-position: center;
+  background-repeat: no-repeat;
+  height: 80px;
+}
+.busy-progressbar-container {
+  width: 100%;
+}
+.busy-indicator-text {
+  margin-top: 2em;
 }
 .editor-menu .menu-item:hover {
   box-shadow: #fff 0 0 5px 0;

--- a/components/pedigree/resources/src/main/resources/pedigree/externalEndpoints.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/externalEndpoints.js
@@ -107,6 +107,10 @@ define([
             return this.vocabulariesService + "/omim";
         },
 
+        getPatientDeleteURL: function(patientId) {
+            return XWiki.contextPath + "/rest/patients/" + patientId + "?method=DELETE";
+        },
+
         getPatientSuggestServiceURL: function() {
             return this.patientSuggestService.getURL("get", 'outputSyntax=plain&rand='+ Math.random());
         },
@@ -114,6 +118,10 @@ define([
         // contextaction is optional parameter
         getPhenotipsPatientURL: function(patientId, contextaction) {
             return new XWiki.Document(patientId, 'data').getURL(contextaction);
+        },
+
+        getPhenotipsPatientHTMLLink: function(patientId) {
+            return "<a href='" + this.getPhenotipsPatientURL(patientId) + "'>" + patientId + "</a>";
         },
 
         // contextaction is optional parameter

--- a/components/pedigree/resources/src/main/resources/pedigree/model/dynamicGraph.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/model/dynamicGraph.js
@@ -81,7 +81,7 @@ define([
             if (htmlPatientLink) {
                 var space = "&nbsp;";
                 if (phenotipsId != "") {
-                    phenotipsId = "<a href='" + editor.getExternalEndpoint().getPhenotipsPatientURL(phenotipsId) + "'>" + phenotipsId + "</a>";
+                    phenotipsId = editor.getExternalEndpoint().getPhenotipsPatientHTMLLink(phenotipsId);
                 }
             }
             var props = this.getProperties(id);

--- a/components/pedigree/resources/src/main/resources/pedigree/patientDataLoader.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/patientDataLoader.js
@@ -9,24 +9,26 @@ define(["pedigree/model/helpers"], function(Helpers){
     var PatientDataLoader = Class.create( {
         initialize: function() {
             this._patientData = {};    // ...as last loaded from PhenoTips
+
+            document.observe("pedigree:patient:deleted", this.handlePatientDeleted.bind(this));
         },
 
         load: function(patientList, dataProcessorWhenReady) {
             if (patientList.length == 0) {
                 dataProcessorWhenReady(this._patientData);
-                document.fire("pedigree:load:finish");
+                document.fire("pedigree:blockinteraction:finish");
                 return;
             }
             var _this = this;
             var patientDataJsonURL = editor.getExternalEndpoint().getLoadPatientDataJSONURL(patientList);
-            document.fire("pedigree:load:start");
+            document.fire("pedigree:blockinteraction:start");
             new Ajax.Request(patientDataJsonURL, {
                 method: "GET",
                 onSuccess: this._onPatientDataReady.bind(this),
-                onComplete: dataProcessorWhenReady ? function() {
-                    dataProcessorWhenReady(_this._patientData);
-                    document.fire("pedigree:load:finish");
-                } : function() { document.fire("pedigree:load:finish"); }
+                onComplete: function() {
+                    dataProcessorWhenReady && dataProcessorWhenReady(_this._patientData);
+                    document.fire("pedigree:blockinteraction:finish");
+                }
             });
         },
 
@@ -37,6 +39,11 @@ define(["pedigree/model/helpers"], function(Helpers){
             } else {
                 console.log("[!] Error parsing patient data JSON");
             }
+        },
+
+        handlePatientDeleted: function(event)
+        {
+            delete this._patientData[event.memo.phenotipsPatientID];
         }
     });
 

--- a/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
@@ -31,7 +31,7 @@ define([
 
         createGraphFromSerializedData: function(JSONString, noUndo, centerAroundProband, callbackWhenDataLoaded, dataSource) {
             console.log("---- load: parsing data ----");
-            document.fire("pedigree:load:start");
+            document.fire("pedigree:blockinteraction:start");
 
             try {
                 var jsonObject = JSON.parse(JSONString);
@@ -48,7 +48,7 @@ define([
             {
                 console.log("ERROR loading pedigree: " + err);
                 alert("Error loading pedigree");
-                document.fire("pedigree:load:finish");
+                document.fire("pedigree:blockinteraction:finish");
 
                 // if there is no pedigree and import was used to initialize a pedigree need to display the import dialogue again
                 if (!editor.pedigreeExists()) {
@@ -62,7 +62,7 @@ define([
 
         createGraphFromImportData: function(importString, importType, importOptions, noUndo, centerAroundProband, dataSource) {
             console.log("---- import: parsing data ----");
-            document.fire("pedigree:load:start");
+            document.fire("pedigree:blockinteraction:start");
 
             try {
                 var changeSet = editor.getGraph().fromImport(importString, importType, importOptions);
@@ -74,7 +74,7 @@ define([
             {
                 console.log("ERROR importing pedigree: " + err);
                 alert("Error importing pedigree: " + err);
-                document.fire("pedigree:load:finish");
+                document.fire("pedigree:blockinteraction:finish");
 
                 // if there is no pedigree and import was used to initialize a pedigree need to display the import dialogue again
                 if (!editor.pedigreeExists()) {
@@ -151,7 +151,7 @@ define([
                     editor.getWorkspace().centerAroundNode(editor.getGraph().getProbandId());
                 }
 
-                document.fire("pedigree:load:finish");
+                document.fire("pedigree:blockinteraction:finish");
             };
 
             if (!noUndo && !editor.isReadOnlyMode()) {
@@ -205,7 +205,7 @@ define([
                     Helpers.disableMouseclicks(closeButton);
                     Helpers.disableMouseclicks(saveButton);
                     // disable user interaction while save is in progress
-                    document.fire("pedigree:load:start", {"message": "Saving pedigree..."});
+                    document.fire("pedigree:blockinteraction:start", {"message": "Saving pedigree..."});
                 },
                 onComplete: function() {
                     me._saveInProgress = false;
@@ -222,7 +222,7 @@ define([
                     Helpers.enableMouseclicks(closeButton);
                     Helpers.enableMouseclicks(saveButton);
                     // Re-enable user-interaction
-                    document.fire("pedigree:load:finish");
+                    document.fire("pedigree:blockinteraction:finish");
                     if (me._notSaved) {
                         callAfterFailedSave && callAfterFailedSave();
                     } else {
@@ -260,7 +260,6 @@ define([
                             editor.getUndoRedoManager().addSaveEvent();
                             editor.getFamilyData().updateFromJSON(response.responseJSON.family);
                             savingNotification.replace(new XWiki.widgets.Notification("Successfully saved"));
-                            document.fire("pedigree:save:finish");
                         }
                     } else  {
                         savingNotification.replace(new XWiki.widgets.Notification("Save attempt failed: server reply is incorrect"));
@@ -280,7 +279,7 @@ define([
             new Ajax.Request(familyJsonURL, {
                 method: "POST",
                 onCreate: function() {
-                    document.fire("pedigree:load:start", {"message": "Loading pedigree..."});
+                    document.fire("pedigree:blockinteraction:start", {"message": "Loading pedigree..."});
                 },
                 onSuccess: function(response) {
                     if (response.responseJSON) {
@@ -353,7 +352,7 @@ define([
         },
 
         initializeNewPedigree: function(showImportTab) {
-            document.fire("pedigree:load:finish");
+            document.fire("pedigree:blockinteraction:finish");
             editor.getTemplateImportSelector().show(showImportTab ? 1 : 0, false,
                 "No pedigree is currently defined. Please select a template to start a pedigree, or import an existing pedigree",
                 "box infomessage"

--- a/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
@@ -205,7 +205,7 @@ define([
                     Helpers.disableMouseclicks(closeButton);
                     Helpers.disableMouseclicks(saveButton);
                     // disable user interaction while save is in progress
-                    document.fire("pedigree:load:start");
+                    document.fire("pedigree:load:start", {"message": "Saving pedigree..."});
                 },
                 onComplete: function() {
                     me._saveInProgress = false;
@@ -280,7 +280,7 @@ define([
             new Ajax.Request(familyJsonURL, {
                 method: "POST",
                 onCreate: function() {
-                    document.fire("pedigree:load:start");
+                    document.fire("pedigree:load:start", {"message": "Loading pedigree..."});
                 },
                 onSuccess: function(response) {
                     if (response.responseJSON) {

--- a/components/pedigree/resources/src/main/resources/pedigree/undoRedoManager.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/undoRedoManager.js
@@ -16,20 +16,15 @@ define([
             this._MAXUNDOSIZE  = 100;
             this._savedState   = "";
 
-            // set of patient records that have been deleted and are now completely unavailable
-            this._deletedPatients = {};
-            // observe pation deletion/creation events to update this._deletedPatients accordingly
+            // observe patient deletion events to remove all references to the deleted patient from all undo/redo states
             document.observe("pedigree:patient:deleted", this.handlePatientDeleted.bind(this));
-            document.observe("pedigree:patient:created", this.handlePatientCreated.bind(this));
         },
 
         handlePatientDeleted: function(event)
         {
             var removedID = event.memo.phenotipsPatientID;
 
-            this._deletedPatients[removedID] = true;
-
-            // Need to modify the undo/redo stack and remoe all references o the deleted patient:
+            // Need to modify the undo/redo stack and remove all references to the deleted patient:
             // 1) change all events to assign/unassign this PT patient to/from a node to a "no op" event
             // 2) remove all links to this patient from all stored states
             this._stack.forEach(function(state) {
@@ -55,11 +50,6 @@ define([
                 });
                 state.serializedState = JSON.stringify(stateJSON);
             });
-        },
-
-        handlePatientCreated: function(event)
-        {
-            delete this._deletedPatients[event.memo.phenotipsPatientID];
         },
 
         hasUnsavedChanges: function() {

--- a/components/pedigree/resources/src/main/resources/pedigree/view/legend.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/legend.js
@@ -683,6 +683,7 @@ define([
             if (editor.isReadOnlyMode()) {
                 return;
             }
+            editor.getNodeMenu().hide();
             editor.getView().setCurrentDraggable(-1); // in drag mode but with no target
             var divPos = editor.getWorkspace().viewportToDiv(event.pointerX(), event.pointerY());
             var pos    = editor.getWorkspace().divToCanvas(divPos.x,divPos.y);

--- a/components/pedigree/resources/src/main/resources/pedigree/view/legend.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/legend.js
@@ -683,7 +683,7 @@ define([
             if (editor.isReadOnlyMode()) {
                 return;
             }
-            editor.getNodeMenu().hide();
+
             editor.getView().setCurrentDraggable(-1); // in drag mode but with no target
             var divPos = editor.getWorkspace().viewportToDiv(event.pointerX(), event.pointerY());
             var pos    = editor.getWorkspace().divToCanvas(divPos.x,divPos.y);

--- a/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
@@ -658,11 +658,11 @@ define([
 
                     var processCreatePatient = function() {
                         var createPatientURL = editor.getExternalEndpoint().getFamilyNewPatientURL();
-                        document.fire("pedigree:load:start", {"message": "Waiting for the patient record to be created..."});
+                        document.fire("pedigree:blockinteraction:start", {"message": "Waiting for the patient record to be created..."});
                         new Ajax.Request(createPatientURL, {
                             method: "GET",
                             onSuccess: _onPatientCreated,
-                            onComplete: function() { document.fire("pedigree:load:finish"); }
+                            onComplete: function() { document.fire("pedigree:blockinteraction:finish"); }
                         });
                     }
 

--- a/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
@@ -649,6 +649,7 @@ define([
                         if (response.responseJSON && response.responseJSON.hasOwnProperty("newID")) {
                             console.log("Created new patient: " + Helpers.stringifyObject(response.responseJSON));
                             Event.fire(patientPicker, 'custom:selection:changed', { "useValue": response.responseJSON.newID, "eventDetails": {"loadPatientProperties": false, "skipConfirmDialogue" : true} });
+                            Event.fire(patientPicker, 'pedigree:patient:created', { "phenotipsPatientID": response.responseJSON.newID });
                             _this.reposition();
                         } else {
                             alert("Patient creation failed");
@@ -657,7 +658,7 @@ define([
 
                     var processCreatePatient = function() {
                         var createPatientURL = editor.getExternalEndpoint().getFamilyNewPatientURL();
-                        document.fire("pedigree:load:start");
+                        document.fire("pedigree:load:start", {"message": "Waiting for the patient record to be created..."});
                         new Ajax.Request(createPatientURL, {
                             method: "GET",
                             onSuccess: _onPatientCreated,

--- a/components/pedigree/resources/src/main/resources/pedigree/view/okCancelDialogue.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/okCancelDialogue.js
@@ -42,26 +42,34 @@ define([], function(){
        *
        * @method show
        */
-      showWithCheckbox: function(message, title, checkboxText, defaultState, okButtonText, onOKFunction, cancelButtonText, onCancelFunction) {
+      showWithCheckbox: function(message, title, checkboxText, defaultState,
+                                 okButtonText, onOKFunction,
+                                 cancelButtonText, onCancelFunction,
+                                 optionalThirdButtonText, optionalThirdButtonFunction) {
           // add checkbox
           var message = message + '<br/><input ' + (defaultState ? 'checked ' : '') + 'type="checkbox" id ="okcancelcheckbox" value="checked">' +
                                   '<label class="field-no-user-select" for="okcancelcheckbox">' + checkboxText + '</label>';
-          var onOK = function() {
+
+          var getState = function() {
               // read checkbox state & clal original onOK with the state as the parameter
               var checkbox = $$('input[type=checkbox][id="okcancelcheckbox"]');
-              var state = checkbox ? checkbox[0].checked : defaultState;
-              onOKFunction(state);
+              return (checkbox ? checkbox[0].checked : defaultState);
+          }
+          var onOK = function() {
+              onOKFunction(getState());
           }
           var onCancel = function() {
-              var checkbox = $$('input[type=checkbox][id="okcancelcheckbox"]');
-              var state = checkbox ? checkbox[0].checked : defaultState;
-              onCancelFunction(state);
+              onCancelFunction(getState());
           }
-          this.showCustomized(message, title, okButtonText, onOK, cancelButtonText, onCancelFunction);
+          var onThirdButton = function() {
+              optionalThirdButtonFunction(getState());
+          }
+          this.showCustomized(message, title, okButtonText, onOK, cancelButtonText, onCancelFunction,
+                  optionalThirdButtonText, onThirdButton, true);
       },
 
       /**
-       * Displays the dialogue
+       * Displays the dialogue (vanilla OK\Cancel sytyle)
        *
        * @method show
        */

--- a/components/pedigree/resources/src/main/resources/pedigree/view/patientDropLegend.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/patientDropLegend.js
@@ -67,7 +67,7 @@ define([
                 removeCase(event.memo.phenotipsID);
             });
 
-            // remove patient from a legen on patient record deleted event
+            // remove patient from a legend on patient record deleted event
             document.observe('pedigree:patient:deleted', function (event){
                 removeCase(event.memo.phenotipsPatientID);
             });

--- a/components/pedigree/resources/src/main/resources/pedigree/view/saveLoadIndicator.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/saveLoadIndicator.js
@@ -1,5 +1,5 @@
 /**
- * SaveLoadIndicator is a window that notifies the user of loading and saving progress.
+ * SaveLoadIndicator is a window that notifies the user of a blocking operation, such as load, save or patient deletion.
  *
  * @class SaveLoadIndicator
  * @constructor
@@ -9,12 +9,19 @@ define([], function(){
 
         initialize: function() {
             var me = this;
-            var mainDiv = new Element('div', {'class': 'load-status-container'});
+            var mainDiv = new Element('div', {'class': 'busy-indicator-content'});
+
+            this.textDiv = new Element('div', {'class': 'busy-indicator-text'});
+            this.progressBarDiv = new Element('div', {'class': 'busy-progressbar-container loading-indicator'});
+
+            mainDiv.insert(this.textDiv).insert(this.progressBarDiv);
+
             this._isHidden = true;
-            this.dialog = new PhenoTips.widgets.ModalPopup(mainDiv, {'close': {'method': null, 'keys': []} }, {extraClassName: "loading-indicator", displayCloseButton: false});
+            this.dialog = new PhenoTips.widgets.ModalPopup(mainDiv, {'close': {'method': null, 'keys': []} }, {displayCloseButton: false});
             document.observe("pedigree:load:start", function(event) {
                 if(me._isHidden) {
-                    me.show();
+                    var message = event.memo.hasOwnProperty("message") ? event.memo.message : null;
+                    me.show(message);
                 }
             });
             document.observe("pedigree:load:finish", function(event) {
@@ -28,7 +35,13 @@ define([], function(){
          * Displays the the loading window
          * @method show
          */
-        show: function() {
+        show: function(message) {
+            if (message) {
+                this.textDiv.update(message);
+                this.textDiv.show();
+            } else {
+                this.textDiv.hide();
+            }
             this.dialog.show();
             this._isHidden = false;
         },

--- a/components/pedigree/resources/src/main/resources/pedigree/view/saveLoadIndicator.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/saveLoadIndicator.js
@@ -18,13 +18,13 @@ define([], function(){
 
             this._isHidden = true;
             this.dialog = new PhenoTips.widgets.ModalPopup(mainDiv, {'close': {'method': null, 'keys': []} }, {displayCloseButton: false});
-            document.observe("pedigree:load:start", function(event) {
+            document.observe("pedigree:blockinteraction:start", function(event) {
                 if(me._isHidden) {
                     var message = event.memo.hasOwnProperty("message") ? event.memo.message : null;
                     me.show(message);
                 }
             });
-            document.observe("pedigree:load:finish", function(event) {
+            document.observe("pedigree:blockinteraction:finish", function(event) {
                 if(!me._isHidden) {
                     me.hide();
                 }


### PR DESCRIPTION
When a patient is unlinked, there is now a new button in the corner of the dialogue to remove the patient record being unlinked.

In addition to the obvious functionality (record deletion/error handling) need to make sure undo/redo works as expected, which in this case means "previous pedigree states look as they used to, except that the deleted record is removed". This should be so for all "undo" states, including those produced by changes unrelated to this patient record.