### PR TITLE
PT-3517: Use lighter shade of gray for placeholder text displayed in the genetic variants fields

### DIFF
--- a/components/skin/ui/src/main/resources/ColorThemes/Kiwi.xml
+++ b/components/skin/ui/src/main/resources/ColorThemes/Kiwi.xml
@@ -790,7 +790,7 @@
       <textPrimaryColor>#888888</textPrimaryColor>
     </property>
     <property>
-      <textSecondaryColor>#888888</textSecondaryColor>
+      <textSecondaryColor>#9F9F9F</textSecondaryColor>
     </property>
     <property>
       <titleColor>#414141</titleColor>

--- a/components/skin/ui/src/main/resources/ColorThemes/Kiwi.xml
+++ b/components/skin/ui/src/main/resources/ColorThemes/Kiwi.xml
@@ -790,7 +790,7 @@
       <textPrimaryColor>#888888</textPrimaryColor>
     </property>
     <property>
-      <textSecondaryColor>#656565</textSecondaryColor>
+      <textSecondaryColor>#888888</textSecondaryColor>
     </property>
     <property>
       <titleColor>#414141</titleColor>

--- a/components/skin/ui/src/main/resources/ColorThemes/Orange.xml
+++ b/components/skin/ui/src/main/resources/ColorThemes/Orange.xml
@@ -778,7 +778,7 @@
       <textPrimaryColor>#656565</textPrimaryColor>
     </property>
     <property>
-      <textSecondaryColor>#656565</textSecondaryColor>
+      <textSecondaryColor>#888888</textSecondaryColor>
     </property>
     <property>
       <titleColor>#4D4D4D</titleColor>

--- a/components/skin/ui/src/main/resources/ColorThemes/Orange.xml
+++ b/components/skin/ui/src/main/resources/ColorThemes/Orange.xml
@@ -778,7 +778,7 @@
       <textPrimaryColor>#656565</textPrimaryColor>
     </property>
     <property>
-      <textSecondaryColor>#888888</textSecondaryColor>
+      <textSecondaryColor>#9F9F9F</textSecondaryColor>
     </property>
     <property>
       <titleColor>#4D4D4D</titleColor>


### PR DESCRIPTION
This affects the Kiwi and Orange color themes.