### PR TITLE
PT-2391: Clicking N/A on a dropdown prenatal phenotype doesn't do the same on the duplicate.

### DIFF
--- a/components/widgets/ui/src/main/resources/PhenoTips/YesNoNAPicker.xml
+++ b/components/widgets/ui/src/main/resources/PhenoTips/YesNoNAPicker.xml
@@ -277,7 +277,7 @@ $xwiki.ssx.use('PhenoTips.YesNoNAPicker')##
     var value = element.value;
     var selected = element.checked;
     var label = element.parentNode;
-    if (value != this.yesInput.value || !selected || !label) {
+    if (value != this.yesInput.value || !selected || !label || !value.startsWith("HP:")) {
       return;
     }
     if (label.hasClassName('na')) {


### PR DESCRIPTION
Excluding YesNoNA pickers with values "0" and "1" from HPO terms syncing