### PR TITLE
PT-3488: Pedigree action buttons not looking good when scaling down below 90%

### DIFF
--- a/components/navigation/ui/src/main/resources/PhenoTips/DBWebHomeSheet.xml
+++ b/components/navigation/ui/src/main/resources/PhenoTips/DBWebHomeSheet.xml
@@ -478,6 +478,11 @@ document.observe('xwiki:livetable:newrow', function(tableEvent){
   transform-origin: 0 0;
 }
 
+.entity-directory .tipfilters .toggle-filters {
+  /* This overrides the general rule for buttons, since "white-space: pre-wrap" causes the expand-marker/collapse-marker to be pushed under the title bar. */
+  white-space: normal;
+}
+
 /* Collapse and expand markers */
 .toggle-filters .collapse-marker, .collapsed .toggle-filters .expand-marker {
   display: inline-block;


### PR DESCRIPTION
Fixed regression: on the "Browse all patients/families" pages, the advanced filters collapse/expand doesn't work nice:
- in Firefox, the guillemet appears below the blue title bar instead of inside it
- in Chrome, the title bar collapses to the right instead of the left