### PR TITLE
CORE-8: Patient data REST for labeled external IDs

### DIFF
--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
@@ -65,7 +65,7 @@ public interface PatientByLabeledExternalIdentifierResource
      * change is performed and an error is returned. If the indicated patient record doesn't exist, however a valid
      * JSON is provided with the query parameter "create" set to true, then a new patient record is created with the
      * provided data; otherwise no change is performed and an error is returned. If multiple records exist with the
-     * same givenidentifier for the given label, no change is performed, and a list of links to each such record is
+     * same given identifier for the given label, no change is performed, and a list of links to each such record is
      * returned. If a field is set in the patient record, but missing in the JSON, then that field is not changed.
      *
      * @param json the JSON representation of the new patient to add
@@ -80,7 +80,7 @@ public interface PatientByLabeledExternalIdentifierResource
     @RequiredAccess("edit")
     Response updatePatient(String json, @PathParam("label") String label, @PathParam("id") String id,
         @QueryParam("policy") @DefaultValue("update") String policy,
-        @QueryParam("create") @DefaultValue("false") String create);
+        @QueryParam("create") @DefaultValue("false") boolean create);
 
     /**
      * Update a patient record, identified by an arbitrary label and its corresponding identifier value, from its JSON
@@ -102,7 +102,7 @@ public interface PatientByLabeledExternalIdentifierResource
     @Consumes(MediaType.APPLICATION_JSON)
     @RequiredAccess("edit")
     Response patchPatient(String json, @PathParam("label") String label, @PathParam("id") String id,
-        @QueryParam("create") @DefaultValue("false") String create);
+        @QueryParam("create") @DefaultValue("false") boolean create);
 
     /**
      * Delete a patient record, identified by an arbitrary label and its corresponding identifier value. If the

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
@@ -62,41 +62,47 @@ public interface PatientByLabeledExternalIdentifierResource
     /**
      * Update a patient record, identified by an arbitrary label and its corresponding identifier value, from its JSON
      * representation. If the user sending the request doesn't have the right to edit the target patient record, no
-     * change is performed and an error is returned. If the indicated patient record doesn't exist, and a valid JSON is
-     * provided, no change is performed and an error is returned. If multiple records exist with the same given
-     * identifier for the given label, no change is performed, and a list of links to each such record is returned. If
-     * a field is set in the patient record, but missing in the JSON, then that field is not changed.
+     * change is performed and an error is returned. If the indicated patient record doesn't exist, however a valid
+     * JSON is provided with the query parameter "create" set to true, then a new patient record is created with the
+     * provided data; otherwise no change is performed and an error is returned. If multiple records exist with the
+     * same givenidentifier for the given label, no change is performed, and a list of links to each such record is
+     * returned. If a field is set in the patient record, but missing in the JSON, then that field is not changed.
      *
      * @param json the JSON representation of the new patient to add
      * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
      * @param id the patient's given external identifier for the given label
      * @param policy the policy according to which patient data should be written
+     * @param create whether a patient record should be created given none exist for the label and id provided
      * @return a status message
      */
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @RequiredAccess("edit")
     Response updatePatient(String json, @PathParam("label") String label, @PathParam("id") String id,
-        @QueryParam("policy") @DefaultValue("update") String policy);
+        @QueryParam("policy") @DefaultValue("update") String policy,
+        @QueryParam("create") @DefaultValue("false") String create);
 
     /**
      * Update a patient record, identified by an arbitrary label and its corresponding identifier value, from its JSON
      * representation. Existing patient data is merged with the provided JSON representation, if possible. If the user
      * sending the request doesn't have the right to edit the target patient record, no change is performed and an
-     * error is returned. If the indicated patient record doesn't exist, no change is performed and an error is
-     * returned. If multiple records exist with the same given identifier for the given label, no change is performed,
-     * and a list of links to each such record is returned. If a field is set in the patient record, but missing in
-     * the JSON, then that field is not changed.
+     * error is returned. If the indicated patient record doesn't exist, however a valid JSON is provided with the
+     * query parameter "create" set to true, then a new patient record is created with the provided data; otherwise no
+     * change is performed and an error is returned. If multiple records exist with the same given identifier for the
+     * given label, no change is performed, and a list of links to each such record is returned. If a field is set in
+     * the patient record, but missing in the JSON, then that field is not changed.
      *
      * @param json the JSON representation of the new patient to add
      * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
      * @param id the patient's given external identifier for the given label
+     * @param create whether a patient record should be created given none exist for the label and id provided
      * @return a status message
      */
     @PATCH
     @Consumes(MediaType.APPLICATION_JSON)
     @RequiredAccess("edit")
-    Response patchPatient(String json, @PathParam("label") String label, @PathParam("id") String id);
+    Response patchPatient(String json, @PathParam("label") String label, @PathParam("id") String id,
+        @QueryParam("create") @DefaultValue("false") String create);
 
     /**
      * Delete a patient record, identified by an arbitrary label and its corresponding identifier value. If the

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
@@ -1,3 +1,20 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
 package org.phenotips.data.rest;
 
 import org.phenotips.rest.PATCH;
@@ -30,7 +47,7 @@ public interface PatientByLabeledExternalIdentifierResource
      * Retrieve a patient record, identified by an arbitrary label and its corresponding identifier value, in its JSON
      * representation. If the indicated label doesn't exist, if the indicated patient record doesn't exist, or if the
      * user sending the request doesn't have the right to view the target patient record, an error is returned. If
-     * multiple records exist with  with the same given identifier for tshe given label, a list of links to each such
+     * multiple records exist with  with the same given identifier for the given label, a list of links to each such
      * record is returned.
      *
      * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
@@ -83,7 +100,7 @@ public interface PatientByLabeledExternalIdentifierResource
 
     /**
      * Delete a patient record, identified by an arbitrary label and its corresponding identifier value. If the
-     * indicated patient record doesn't exist, or if the user sending the request doesn't have the right to edit the
+     * indicated patient record doesn't exist, or if the user sending the request doesn't have the right to delete the
      * target patient record, no change is performed and an error is returned. If multiple records exist with the same
      * given identifier for the given label, no change is performed, and a list of links to each such record is
      * returned.

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/PatientByLabeledExternalIdentifierResource.java
@@ -1,0 +1,98 @@
+package org.phenotips.data.rest;
+
+import org.phenotips.rest.PATCH;
+import org.phenotips.rest.ParentResource;
+import org.phenotips.rest.RequiredAccess;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Resource for working with patient records where patients records are identified and manipulated using an arbitrary
+ * label and a corresponding identifier value, fields of the {@code LabeledIdentifierClass}.
+ *
+ * @version $Id$
+ */
+@Path("/patients/labeled-eid/{label}/{id}")
+@ParentResource(PatientsResource.class)
+public interface PatientByLabeledExternalIdentifierResource
+{
+    /**
+     * Retrieve a patient record, identified by an arbitrary label and its corresponding identifier value, in its JSON
+     * representation. If the indicated label doesn't exist, if the indicated patient record doesn't exist, or if the
+     * user sending the request doesn't have the right to view the target patient record, an error is returned. If
+     * multiple records exist with  with the same given identifier for tshe given label, a list of links to each such
+     * record is returned.
+     *
+     * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
+     * @param id the patient's given external identifier for the given label
+     * @return the JSON representation of the requested patient, or a status message in case of error
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequiredAccess("view")
+    Response getPatient(@PathParam("label") String label, @PathParam("id") String id);
+
+    /**
+     * Update a patient record, identified by an arbitrary label and its corresponding identifier value, from its JSON
+     * representation. If the user sending the request doesn't have the right to edit the target patient record, no
+     * change is performed and an error is returned. If the indicated patient record doesn't exist, and a valid JSON is
+     * provided, no change is performed and an error is returned. If multiple records exist with the same given
+     * identifier for the given label, no change is performed, and a list of links to each such record is returned. If
+     * a field is set in the patient record, but missing in the JSON, then that field is not changed.
+     *
+     * @param json the JSON representation of the new patient to add
+     * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
+     * @param id the patient's given external identifier for the given label
+     * @param policy the policy according to which patient data should be written
+     * @return a status message
+     */
+    @PUT
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RequiredAccess("edit")
+    Response updatePatient(String json, @PathParam("label") String label, @PathParam("id") String id,
+        @QueryParam("policy") @DefaultValue("update") String policy);
+
+    /**
+     * Update a patient record, identified by an arbitrary label and its corresponding identifier value, from its JSON
+     * representation. Existing patient data is merged with the provided JSON representation, if possible. If the user
+     * sending the request doesn't have the right to edit the target patient record, no change is performed and an
+     * error is returned. If the indicated patient record doesn't exist, no change is performed and an error is
+     * returned. If multiple records exist with the same given identifier for the given label, no change is performed,
+     * and a list of links to each such record is returned. If a field is set in the patient record, but missing in
+     * the JSON, then that field is not changed.
+     *
+     * @param json the JSON representation of the new patient to add
+     * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
+     * @param id the patient's given external identifier for the given label
+     * @return a status message
+     */
+    @PATCH
+    @Consumes(MediaType.APPLICATION_JSON)
+    @RequiredAccess("edit")
+    Response patchPatient(String json, @PathParam("label") String label, @PathParam("id") String id);
+
+    /**
+     * Delete a patient record, identified by an arbitrary label and its corresponding identifier value. If the
+     * indicated patient record doesn't exist, or if the user sending the request doesn't have the right to edit the
+     * target patient record, no change is performed and an error is returned. If multiple records exist with the same
+     * given identifier for the given label, no change is performed, and a list of links to each such record is
+     * returned.
+     *
+     * @param label an arbitrary label, either exists in all patients, or exists in at least one patient
+     * @param id the patient's given external identifier for the given label
+     * @return a status message
+     */
+    @DELETE
+    @RequiredAccess("edit")
+    Response deletePatient(@PathParam("label") String label, @PathParam("id") String id);
+}

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImpl.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImpl.java
@@ -1,3 +1,20 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
 package org.phenotips.data.rest.internal;
 
 import org.phenotips.data.Patient;

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImpl.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImpl.java
@@ -1,0 +1,326 @@
+package org.phenotips.data.rest.internal;
+
+import org.phenotips.data.Patient;
+import org.phenotips.data.PatientRepository;
+import org.phenotips.data.PatientWritePolicy;
+import org.phenotips.data.rest.DomainObjectFactory;
+import org.phenotips.data.rest.PatientByLabeledExternalIdentifierResource;
+import org.phenotips.data.rest.PatientResource;
+import org.phenotips.rest.Autolinker;
+import org.phenotips.security.authorization.AuthorizationService;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
+import org.xwiki.rest.XWikiResource;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.users.User;
+import org.xwiki.users.UserManager;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+
+/**
+ * Default implementation for {@link PatientByLabeledExternalIdentifierResource} using XWiki's support for REST
+ * resources.
+ *
+ * @version $Id$
+ */
+@Component
+@Named("org.phenotips.data.rest.internal.DefaultPatientByLabeledExternalIdentifierResourceImpl")
+@Singleton
+public class DefaultPatientByLabeledExternalIdentifierResourceImpl extends XWikiResource implements
+    PatientByLabeledExternalIdentifierResource
+{
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private PatientRepository repository;
+
+    @Inject
+    private DomainObjectFactory factory;
+
+    @Inject
+    private QueryManager qm;
+
+    @Inject
+    private AuthorizationService access;
+
+    @Inject
+    private UserManager users;
+
+    @Inject
+    private Provider<Autolinker> autolinker;
+
+    @Override
+    public Response getPatient(String label, String id)
+    {
+        this.logger.debug("Retrieving patient record with label [{}] and corresponding external ID [{}] via REST",
+            label, id);
+        Patient patient;
+        List<String> patients = getPatientDocumentReferencesByLabelAndEid(label, id);
+        if (patients.size() == 1) {
+            patient = this.repository.get(patients.get(0));
+        } else {
+            return returnIfEmptyOrMultipleExistsResponse(patients, label, id);
+        }
+
+        User currentUser = this.users.getCurrentUser();
+        Right grantedRight;
+        if (!this.access.hasAccess(currentUser, Right.VIEW, patient.getDocumentReference())) {
+            this.logger.debug("View access denied to user [{}] on patient record [{}]", currentUser, patient.getId());
+            return Response.status(Response.Status.FORBIDDEN).build();
+        } else {
+            grantedRight = Right.VIEW;
+        }
+        if (this.access.hasAccess(currentUser, Right.EDIT, patient.getDocumentReference())) {
+            grantedRight = Right.EDIT;
+        }
+
+        JSONObject json = patient.toJSON();
+        json.put("links", this.autolinker.get().forResource(PatientResource.class, this.uriInfo)
+            .withExtraParameters("entity-id", patient.getId())
+            .withExtraParameters("entity-type", "patients")
+            .withGrantedRight(grantedRight)
+            .build());
+        return Response.ok(json, MediaType.APPLICATION_JSON_TYPE).build();
+    }
+
+    @Override
+    public Response updatePatient(final String json, final String label, final String id, final String policy)
+    {
+        final PatientWritePolicy policyType = PatientWritePolicy.fromString(policy);
+        return updatePatient(json, label, id, policyType);
+    }
+
+    private Response updatePatient(final String json, final String label, final String id,
+        final PatientWritePolicy policy)
+    {
+        this.logger.debug("Updating patient record with label [{}] and corresponding external ID [{}] via REST: {}",
+            label, id, json);
+        if (policy == null) {
+            throw new WebApplicationException(Response.Status.BAD_REQUEST);
+        }
+        if (json == null) {
+            // json == null does not create an exception when initializing a JSONObject
+            // need to handle it separately to give explicit BAD_REQUEST to the user
+            throw new WebApplicationException(Response.Status.BAD_REQUEST);
+        }
+
+        Patient patient;
+        List<String> patients = getPatientDocumentReferencesByLabelAndEid(label, id);
+        if (patients.size() == 1) {
+            patient = this.repository.get(patients.get(0));
+        } else {
+            return returnIfEmptyOrMultipleExistsResponse(patients, label, id);
+        }
+
+        User currentUser = this.users.getCurrentUser();
+        if (!this.access.hasAccess(currentUser, Right.EDIT, patient.getDocumentReference())) {
+            this.logger.debug("Edit access denied to user [{}] on patient record [{}]", currentUser, patient.getId());
+            throw new WebApplicationException(Response.Status.FORBIDDEN);
+        }
+        JSONObject jsonInput;
+        try {
+            jsonInput = new JSONObject(json);
+        } catch (final JSONException ex) {
+            this.logger.error("Provided patient json: {} is invalid.", json, ex);
+            throw new WebApplicationException(Response.Status.BAD_REQUEST);
+        }
+
+        if (hasInternalIdConflict(jsonInput, patient)) {
+            throw new WebApplicationException(Response.Status.CONFLICT);
+        }
+
+        try {
+            patient.updateFromJSON(jsonInput, policy);
+        } catch (Exception ex) {
+            this.logger.warn("Failed to update patient [{}] from JSON: {}. Source JSON was: {}", patient.getId(),
+                ex.getMessage(), json, ex);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        return Response.noContent().build();
+    }
+
+    @Override
+    public Response patchPatient(String json, String label, String id)
+    {
+        return updatePatient(json, label, id, PatientWritePolicy.MERGE);
+    }
+
+    @Override
+    public Response deletePatient(String label, String id)
+    {
+        this.logger.debug("Deleting patient record with label [{}] and corresponding external ID [{}] via REST",
+            label, id);
+        Patient patient;
+        List<String> patients = getPatientDocumentReferencesByLabelAndEid(label, id);
+        if (patients.size() == 1) {
+            patient = this.repository.get(patients.get(0));
+        } else {
+            return returnIfEmptyOrMultipleExistsResponse(patients, label, id);
+        }
+
+        User currentUser = this.users.getCurrentUser();
+        if (!this.access.hasAccess(currentUser, Right.DELETE, patient.getDocumentReference())) {
+            this.logger.debug("Delete access denied to user [{}] on patient record [{}]", currentUser, patient.getId());
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        try {
+            this.repository.delete(patient);
+        } catch (Exception ex) {
+            this.logger.warn("Failed to delete patient record with label [{}] and corresponding external id [{}]: {}",
+                label, id, ex.getMessage(), ex);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+        this.logger.debug("Deleted patient record with label [{}] corresponding external id [{}]", label, id);
+        return Response.noContent().build();
+    }
+
+    private Response returnIfEmptyOrMultipleExistsResponse(List<String> patients, String label, String id)
+    {
+        if (patients.isEmpty()) {
+            this.logger.debug("No patient record with label [{}] and corresponding external ID [{}] exists yet",
+                label, id);
+            return Response.status(Response.Status.NOT_FOUND).build();
+
+        } else {
+            this.logger.debug("Multiple patient records ({}) with label [{}] and corresponding external ID [{}]: {}",
+                patients.size(), label, id, patients);
+            return Response.status(300).entity(this.factory.createAlternatives(patients, this.uriInfo)).build();
+        }
+    }
+
+    /**
+     * Gets a list of patient document references.
+     *
+     * @param label the label for the eid
+     * @param id the value of the eid
+     * @return null if the label is invalid, an empty list if no patients have the label identifier and its
+     *         corresponding id value, else a list of patient document references.
+     */
+    private List<String> getPatientDocumentReferencesByLabelAndEid(String label, String id)
+    {
+        try {
+            // Check global configs first before querying all labeled identifier objects on all patients, much cheaper
+            if (isLabelConfiguredByAdmin(label) || allowOtherEids()) {
+                return queryPatientsByLabelAndEid(label, id);
+            } else {
+                return Collections.emptyList();
+            }
+        } catch (Exception ex) {
+            this.logger.error("Failed to retrieve patient with label [{}] and corresponding external ID [{}]: {}",
+                label, id, ex.getMessage(), ex);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * For a given label and its corresponding id value (fields on {@code LabeledIdentifierClass} objects), query
+     * patient documents.
+     *
+     * @param label the label for the eid
+     * @param id the value of the eid
+     * @return an empty list if no patients have the label identifier and its corresponding id value, else a list of
+     *         patient document references.
+     * @throws Exception if there is any error during querying.
+     */
+    private List<String> queryPatientsByLabelAndEid(String label, String id) throws Exception
+    {
+        Query q = null;
+        try {
+            q = this.qm.createQuery(
+                "select doc.name from Document doc, doc.object(PhenoTips.LabeledIdentifierClass) obj "
+                + "where obj.label = :label and obj.value = :value", Query.XWQL);
+            q.bindValue("label", label);
+            q.bindValue("value", id);
+            return q.execute();
+        } catch (QueryException ex) {
+            this.logger.warn("Failed to query patient documents with label [{}] and corresponding external ID [{}]: {}",
+                label, id, ex.getMessage(), ex);
+            throw new QueryException(ex.getMessage(), q, ex);
+        }
+    }
+
+    /**
+     * Checks if the label in question is configured at the administrative level, which means that the label is
+     * available globally for all patients. If it is, then it will be the {@code label} value of a
+     * {@code LabeledIdentifierSettings} object.
+     *
+     * @param label the label to check
+     * @return true if the label exists, else false.
+     * @throws Exception if there is any error during querying.
+     */
+    private boolean isLabelConfiguredByAdmin(String label) throws Exception
+    {
+        Query q = null;
+        try {
+            q = this.qm.createQuery(
+                "select obj.label from Document doc, doc.object(PhenoTips.LabeledIdentifierSettings) obj "
+                + "where obj.label = :label", Query.XWQL);
+            q.bindValue("label", label);
+            List<String> results = q.execute();
+            return !results.isEmpty();
+        } catch (QueryException ex) {
+            this.logger.warn("Failed to query LabeledIdentifierSettings object: {}", ex.getMessage(), ex);
+            throw new QueryException(ex.getMessage(), q, ex);
+        }
+    }
+
+    /**
+     * Checks whether the global configuration allows for other eids
+     * {@code LabeledIdentifierGlobalSettings.allowOtherEids} to be set arbitrarily by the user for each patient.
+     *
+     * @return true if arbitrary eids are allowed, else false.
+     * @throws Exception if an instance of the {@code LabeledIdentifierGlobalSettings} object cannot be found,
+     *         or if there is any other error during querying.
+     */
+    private boolean allowOtherEids() throws Exception
+    {
+        Query q = null;
+        try {
+            q = this.qm.createQuery("select obj.allowOtherEids from Document doc, doc.object("
+                                          + "PhenoTips.LabeledIdentifierGlobalSettings) obj", Query.XWQL);
+            List<Integer> results = q.execute();
+            if (results == null || results.isEmpty()) {
+                this.logger.debug("There should be one LabeledIdentifierGlobalSettings object. None were found.");
+                throw new Exception("LabeledIdentifierGlobalSettings object not found.");
+            }
+            return results.get(0) != 0;
+        } catch (QueryException ex) {
+            this.logger.warn("Failed to query LabeledIdentifierGlobalSettings object: {}", ex.getMessage(), ex);
+            throw new QueryException(ex.getMessage(), q, ex);
+        }
+    }
+
+    /**
+     * Returns true iff the internal ID is specified in {@code jsonInput} and does not correspond with the patient
+     * internal ID, false otherwise.
+     *
+     * @param jsonInput the patient data being imported
+     * @param patient the {@link Patient} object
+     *
+     * @return true iff the internal ID is specified in {@code jsonInput} and conflicts with patient internal ID, false
+     *         otherwise
+     */
+    private boolean hasInternalIdConflict(final JSONObject jsonInput, final Patient patient)
+    {
+        final String idFromJson = jsonInput.optString("id");
+        return StringUtils.isNotBlank(idFromJson) && !patient.getId().equals(idFromJson);
+    }
+}

--- a/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImpl.java
+++ b/components/patient-data/rest/src/main/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImpl.java
@@ -135,14 +135,14 @@ public class DefaultPatientByLabeledExternalIdentifierResourceImpl extends XWiki
 
     @Override
     public Response updatePatient(final String json, final String label, final String id,
-        final String policy, final String create)
+        final String policy, final boolean create)
     {
         final PatientWritePolicy policyType = PatientWritePolicy.fromString(policy);
         return updatePatient(json, label, id, policyType, create);
     }
 
     private Response updatePatient(final String json, final String label, final String id,
-        final PatientWritePolicy policy, final String create)
+        final PatientWritePolicy policy, final boolean create)
     {
         this.logger.debug("Updating patient record with label [{}] and corresponding external ID [{}] via REST: {}",
             label, id, json);
@@ -163,13 +163,12 @@ public class DefaultPatientByLabeledExternalIdentifierResourceImpl extends XWiki
             throw new WebApplicationException(Response.Status.BAD_REQUEST);
         }
 
-        boolean shouldCreate = Boolean.parseBoolean(create);
         Patient patient;
         List<String> patients = getPatientInternalIdentifiersByLabelAndEid(label, id);
         if (patients.size() == 1) {
             patient = this.repository.get(patients.get(0));
         } else {
-            return returnIfEmptyOrMultipleExistResponse(patients, label, id, jsonInput, shouldCreate);
+            return returnIfEmptyOrMultipleExistResponse(patients, label, id, jsonInput, create);
         }
 
         User currentUser = this.users.getCurrentUser();
@@ -184,7 +183,7 @@ public class DefaultPatientByLabeledExternalIdentifierResourceImpl extends XWiki
     }
 
     @Override
-    public Response patchPatient(String json, String label, String id, String create)
+    public Response patchPatient(String json, String label, String id, boolean create)
     {
         return updatePatient(json, label, id, PatientWritePolicy.MERGE, create);
     }

--- a/components/patient-data/rest/src/main/resources/META-INF/components.txt
+++ b/components/patient-data/rest/src/main/resources/META-INF/components.txt
@@ -1,5 +1,6 @@
 org.phenotips.data.rest.internal.DefaultDomainObjectFactory
 org.phenotips.data.rest.internal.DefaultPatientByExternalIdResourceImpl
+org.phenotips.data.rest.internal.DefaultPatientByLabeledExternalIdentifierResourceImpl
 org.phenotips.data.rest.internal.DefaultPatientResourceImpl
 org.phenotips.data.rest.internal.DefaultPatientsResourceImpl
 org.phenotips.data.rest.internal.DefaultPatientsFetchResourceImpl

--- a/components/patient-data/rest/src/test/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImplTest.java
+++ b/components/patient-data/rest/src/test/java/org/phenotips/data/rest/internal/DefaultPatientByLabeledExternalIdentifierResourceImplTest.java
@@ -1,0 +1,627 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.data.rest.internal;
+
+import org.phenotips.data.Patient;
+import org.phenotips.data.PatientRepository;
+import org.phenotips.data.PatientWritePolicy;
+import org.phenotips.data.internal.PhenoTipsPatient;
+import org.phenotips.data.rest.DomainObjectFactory;
+import org.phenotips.data.rest.PatientByLabeledExternalIdentifierResource;
+import org.phenotips.data.rest.PatientResource;
+import org.phenotips.rest.Autolinker;
+import org.phenotips.security.authorization.AuthorizationService;
+
+import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.util.ReflectionUtils;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceResolver;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
+import org.xwiki.query.internal.DefaultQuery;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.users.User;
+import org.xwiki.users.UserManager;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Named;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DefaultPatientByLabeledExternalIdentifierResourceImplTest
+{
+    private static final String LABEL = "a_label";
+
+    private static final String EID = "eid";
+
+    private static final String ID = "id";
+
+    private static final String PATIENT_ID = "P0000001";
+
+    private static final String EMPTY_JSON = "{}";
+
+    private static final String KEY_LABELED_EIDS = "labeled_eids";
+
+    private static final String KEY_LABEL = "label";
+
+    private static final String KEY_VALUE = "value";
+
+    private static final String UPDATE = "update";
+
+    @Rule
+    public final MockitoComponentMockingRule<PatientByLabeledExternalIdentifierResource> mocker =
+        new MockitoComponentMockingRule<>(DefaultPatientByLabeledExternalIdentifierResourceImpl.class);
+
+    @Mock
+    private Patient patient;
+
+    @Mock
+    private UriInfo uriInfo;
+
+    @Mock
+    private UriBuilder uriBuilder;
+
+    @Mock
+    private User currentUser;
+
+    @Mock
+    private EntityReferenceResolver<EntityReference> resolver;
+
+    private Logger logger;
+
+    private PatientRepository repository;
+
+    private DomainObjectFactory factory;
+
+    private QueryManager qm;
+
+    private AuthorizationService access;
+
+    private DocumentAccessBridge bridge;
+
+    @Named("current")
+    private DocumentReferenceResolver<String> stringResolver;
+
+    private URI uri;
+
+    private DefaultPatientByLabeledExternalIdentifierResourceImpl component;
+
+    private DocumentReference patientReference = new DocumentReference("wiki", "data", PATIENT_ID);
+
+    @Before
+    public void setUp() throws ComponentLookupException, URISyntaxException
+    {
+        MockitoAnnotations.initMocks(this);
+        this.uri = new URI("uri");
+
+        Execution execution = mock(Execution.class);
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        ComponentManager componentManager = this.mocker.getInstance(ComponentManager.class, "context");
+        when(componentManager.getInstance(Execution.class)).thenReturn(execution);
+        doReturn(executionContext).when(execution).getContext();
+        doReturn(mock(XWikiContext.class)).when(executionContext).getProperty("xwikicontext");
+
+        this.repository = this.mocker.getInstance(PatientRepository.class);
+        this.factory = this.mocker.getInstance(DomainObjectFactory.class);
+        this.qm = this.mocker.getInstance(QueryManager.class);
+        this.access = this.mocker.getInstance(AuthorizationService.class);
+        this.bridge = this.mocker.getInstance(DocumentAccessBridge.class);
+        this.stringResolver = this.mocker.getInstance(DocumentReferenceResolver.class);
+
+        final UserManager users = this.mocker.getInstance(UserManager.class);
+        this.component = (DefaultPatientByLabeledExternalIdentifierResourceImpl) this.mocker.getComponentUnderTest();
+        this.logger = this.mocker.getMockedLogger();
+        this.resolver = this.mocker.getInstance(EntityReferenceResolver.TYPE_REFERENCE, "current");
+        ReflectionUtils.setFieldValue(this.component, "uriInfo", this.uriInfo);
+
+        when(this.resolver.resolve(any(EntityReference.class), any(EntityType.class), any()))
+            .thenReturn(mock(EntityReference.class));
+        doReturn(this.uriBuilder).when(this.uriInfo).getBaseUriBuilder();
+        when(this.patient.getId()).thenReturn(ID);
+        when(this.patient.getDocumentReference()).thenReturn(this.patientReference);
+        when(users.getCurrentUser()).thenReturn(this.currentUser);
+        when(this.repository.getByName(EID)).thenReturn(this.patient);
+        when(this.repository.create()).thenReturn(this.patient);
+        when(this.access.hasAccess(this.currentUser, Right.VIEW, this.patientReference)).thenReturn(true);
+        when(this.access.hasAccess(this.currentUser, Right.EDIT, this.patientReference)).thenReturn(true);
+        when(this.access.hasAccess(this.currentUser, Right.DELETE, this.patientReference)).thenReturn(true);
+        when(this.access.hasAccess(eq(this.currentUser), eq(Right.EDIT), any(EntityReference.class)))
+            .thenReturn(true);
+
+        Autolinker autolinker = this.mocker.getInstance(Autolinker.class);
+        when(autolinker.forResource(any(Class.class), any(UriInfo.class))).thenReturn(autolinker);
+        when(autolinker.withGrantedRight(any(Right.class))).thenReturn(autolinker);
+        when(autolinker.withActionableResources(any(Class.class))).thenReturn(autolinker);
+        when(autolinker.withExtraParameters(any(String.class), any(String.class))).thenReturn(autolinker);
+        when(autolinker.build()).thenReturn(Collections
+            .singletonList(new org.phenotips.rest.model.Link().withAllowedMethods(Collections.singletonList("GET"))
+                .withHref(this.uri.toString()).withRel("self")));
+    }
+
+    @Test
+    public void getPatientWithNoAccessReturnsForbiddenCode() throws ComponentLookupException
+    {
+        when(this.access.hasAccess(this.currentUser, Right.VIEW, this.patientReference)).thenReturn(false);
+
+        Response response = this.component.getPatient(LABEL, EID);
+        verify(this.logger).debug("View access denied to user [{}] on patient record [{}]", this.currentUser,
+            this.patient.getId());
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void getPatientPerformsCorrectly() throws ComponentLookupException
+    {
+        JSONObject jsonObject = new JSONObject();
+        when(this.patient.toJSON()).thenReturn(jsonObject);
+        when(this.uriInfo.getBaseUriBuilder()).thenReturn(this.uriBuilder);
+        when(this.uriBuilder.path(PatientResource.class)).thenReturn(this.uriBuilder);
+        when(this.uriBuilder.build(this.patient.getId())).thenReturn(this.uri);
+
+        Response response = this.component.getPatient(LABEL, EID);
+        verify(this.logger).debug("Retrieving patient record with label [{}] and corresponding external ID "
+                                  + "[{}] via REST", LABEL, EID);
+
+        JSONObject links = new JSONObject().accumulate("rel", "self").accumulate("href", "uri")
+            .put("allowedMethods", new JSONArray(Collections.singletonList("GET")));
+        JSONObject json = new JSONObject().put("links", Collections.singletonList(links));
+
+        assertTrue(json.similar(response.getEntity()));
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void getPatientNotFoundChecksForMultipleRecords() throws ComponentLookupException, QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(this.repository.getByName(EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+
+        Response response = this.component.getPatient(LABEL, EID);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void updatePatientNotFoundChecksForMultipleRecords() throws ComponentLookupException, QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(getPatientByLabelAndEid(LABEL, EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+
+        Response response = this.component.updatePatient(EMPTY_JSON, LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void updatePatientNotFoundNewPatientNotCreatedIfInvalidJson() throws QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(this.repository.getByName(EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+
+        Response response = this.component.updatePatient("[]", LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
+        verify(this.repository, never()).create();
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void updatePatientNotFoundNewPatientNotCreatedIfUserDoesNotHaveEditRights() throws QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(this.repository.getByName(EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+        when(this.access.hasAccess(eq(this.currentUser), eq(Right.EDIT), any(EntityReference.class)))
+            .thenReturn(false);
+
+        Response response = this.component.updatePatient(EMPTY_JSON, LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("No patient record with external ID [{}] exists yet", EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
+        verify(this.logger).error("Edit access denied to user [{}].", this.currentUser);
+        verify(this.repository, never()).create();
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void updatePatientNotFoundNewPatientSpecifiesIdInJson() throws QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(this.repository.getByName(EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+
+        Response response = this.component.updatePatient(
+            "{\"labeled_eids\":[{\"label\":\"a_label\", \"value\":\"abc\"}]}", LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("No patient record with label [{}] and corresponding external ID [{}] exists yet",
+            LABEL, EID);
+        verify(this.logger).debug("Creating patient record with external ID [{}]", EID);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+        ArgumentCaptor<JSONObject> json = ArgumentCaptor.forClass(JSONObject.class);
+        verify(this.patient).updateFromJSON(json.capture());
+        assertEquals("abc", json.getValue().optString(KEY_LABELED_EIDS));
+        assertEquals(1, json.getValue().length());
+    }
+
+    @Test
+    public void updatePatientNotFoundNewPatientNoIdInJson() throws QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(getPatientByLabelAndEid(LABEL, EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+
+        Response response = this.component.updatePatient(EMPTY_JSON, LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("No patient record with label [{}] and corresponding external ID [{}] exists yet",
+            LABEL, EID);
+        verify(this.logger).debug("Creating patient record with label [{}] and corresponding external ID [{}]", LABEL, EID);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+
+        ArgumentCaptor<JSONObject> json = ArgumentCaptor.forClass(JSONObject.class);
+        verify(this.patient).updateFromJSON(json.capture());
+        assertEquals(EID, json.getValue().optString(KEY_LABELED_EIDS));
+        assertEquals(1, json.getValue().length());
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void updatePatientNoAccessReturnsForbiddenCode() throws ComponentLookupException
+    {
+        when(this.access.hasAccess(this.currentUser, Right.EDIT, this.patientReference)).thenReturn(false);
+
+        Response response = this.component.updatePatient("json", LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("Edit access denied to user [{}] on patient record [{}]", null, this.patient.getId());
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void updatePatientWrongJSONId() throws ComponentLookupException
+    {
+        this.component.updatePatient("{\"id\":\"notid\"}", LABEL, EID, UPDATE, true);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void updatePatientFromJSONException() throws ComponentLookupException
+    {
+        doThrow(Exception.class).when(this.patient).updateFromJSON(Matchers.any(JSONObject.class), Matchers.any(
+            PatientWritePolicy.class));
+
+        this.component.updatePatient("{\"id\":\"id\"}", LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("Failed to update patient [{}] from JSON: {}. Source JSON was: {}",
+            ID, "{\"id\":\"id\"}");
+    }
+
+    @Test
+    public void updatePatientReturnsNoContentResponse() throws ComponentLookupException
+    {
+        String json = "{\"id\":\"id\"}";
+        Response response = this.component.updatePatient(json, LABEL, EID, UPDATE, true);
+        verify(this.logger).debug("Updating patient record with label [{]] and corresponding external ID [{}] via "
+                                  + "REST with JSON: {}", LABEL, EID, json);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void deletePatientReturnsNotFoundStatus() throws QueryException
+    {
+        Query query = mock(DefaultQuery.class);
+        when(getPatientByLabelAndEid(LABEL, EID)).thenReturn(null);
+        when(this.qm.createQuery(Matchers.anyString(), Matchers.anyString())).thenReturn(query);
+        when(query.execute()).thenReturn(new ArrayList<>());
+
+        Response response = this.component.deletePatient(LABEL, EID);
+
+        verify(this.logger).debug("No patient record with label [{}] and corresponding external ID [{}] exists yet",
+            LABEL, EID);
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void deletePatientNoAccessReturnsForbiddenCode()
+    {
+        when(this.access.hasAccess(this.currentUser, Right.DELETE, this.patientReference)).thenReturn(false);
+
+        Response response = this.component.deletePatient(LABEL, EID);
+
+        verify(this.logger).debug("Delete access denied to user [{}] on patient record [{}]", this.currentUser,
+            this.patient.getId());
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void deletePatientCatchesException() throws WebApplicationException
+    {
+        doThrow(Exception.class).when(this.repository).delete(this.patient);
+        when(getPatientByLabelAndEid(LABEL, EID)).thenReturn(this.patient);
+        when(this.access.hasAccess(null, Right.DELETE, null)).thenReturn(true);
+
+        WebApplicationException ex = null;
+        try {
+            this.component.deletePatient(LABEL, EID);
+        } catch (WebApplicationException temp) {
+            ex = temp;
+        }
+
+        assertNotNull("deletePatient did not throw a WebApplicationException as expected "
+                      + "when catching an Exception", ex);
+        assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), ex.getResponse().getStatus());
+        verify(this.logger).warn(eq("Failed to delete patient record with label [{}] and corresponding "
+                                    + "external id [{}]: {}"), eq(LABEL), eq(EID), anyString());
+    }
+
+    @Test
+    public void deletePatientReturnsNoContentResponse()
+    {
+        Response response = this.component.deletePatient(LABEL, EID);
+
+        verify(this.repository).delete(this.patient);
+        verify(this.logger).debug("Deleting patient record with external ID [{}] via REST", EID);
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void checkForMultipleRecordsPerformsCorrectly() throws QueryException
+    {
+        Query q = mock(DefaultQuery.class);
+        doReturn(q).when(this.qm)
+            .createQuery("select doc.name from Document doc, doc.object(PhenoTips.LabeledIdentifierClass) obj "
+                         + "where obj.label = :label and obj.value = :value", Query.XWQL);
+
+        List<String> results = new ArrayList<>();
+        results.add(EID);
+        results.add(EID);
+        doReturn(results).when(q).execute();
+
+        when(getPatientByLabelAndEid(LABEL, EID)).thenReturn(null);
+
+        Response responseGet = this.component.getPatient(LABEL, EID);
+        Response responseUpdate = this.component.updatePatient(EID, LABEL, EID, UPDATE, true);
+        Response responseDelete = this.component.deletePatient(LABEL, EID);
+
+        verify(this.logger, times(3)).debug("Multiple patient records ({}) with external ID [{}]: {}",
+            2, EID, results);
+        verify(this.factory, times(3)).createAlternatives(anyListOf(String.class), eq(this.uriInfo));
+        assertEquals(300, responseGet.getStatus());
+        assertEquals(300, responseUpdate.getStatus());
+        assertEquals(300, responseDelete.getStatus());
+    }
+
+    @Test
+    public void checkForMultipleRecordsLogsWhenThrowsQueryException() throws QueryException
+    {
+        doThrow(QueryException.class).when(this.qm)
+            .createQuery("select doc.name from Document doc, doc.object(PhenoTips.LabeledIdentifierClass) obj "
+                         + "where obj.label = :label and obj.value = :value", Query.XWQL);
+
+        when(getPatientByLabelAndEid(LABEL, EID)).thenReturn(null);
+
+        Response responseGet = this.component.getPatient(LABEL, EID);
+        Response responseUpdate = this.component.updatePatient(EMPTY_JSON, LABEL, EID, UPDATE, true);
+        Response responseDelete = this.component.deletePatient(LABEL, EID);
+
+        verify(this.logger, times(3)).warn("Failed to retrieve patient with label [{}] " +
+                                           "and corresponding external id [{}]: {}", LABEL, EID, null);
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), responseGet.getStatus());
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), responseUpdate.getStatus());
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), responseDelete.getStatus());
+    }
+
+    // ----------------------------Patch Patient Tests-----------------------------
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientWithNullJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient(null, LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientWithEmptyJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient(StringUtils.EMPTY, LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientWithBlankJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient(StringUtils.SPACE, LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test
+    public void patchPatientNoPatientWithSpecifiedEidExistsResultsPatientBeingCreated() throws QueryException
+    {
+        when(this.repository.get(PATIENT_ID)).thenReturn(null);
+        final Query query = mock(Query.class);
+        when(this.qm.createQuery(anyString(), eq(Query.XWQL))).thenReturn(query);
+        when(query.execute()).thenReturn(Collections.emptyList());
+        final Response response = this.component.patchPatient(EMPTY_JSON, LABEL, PATIENT_ID, true);
+        Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+        verify(this.repository, times(1)).create();
+    }
+
+    @Test
+    public void patchPatientManyPatientsWithSpecifiedEidExistResultsInCorrectResponse() throws QueryException
+    {
+        when(this.repository.get(PATIENT_ID)).thenReturn(null);
+        final Query query = mock(Query.class);
+        when(this.qm.createQuery(anyString(), eq(Query.XWQL))).thenReturn(query);
+        when(query.execute()).thenReturn(Arrays.asList("one", "two"));
+        final Response response = this.component.patchPatient(EMPTY_JSON, LABEL, PATIENT_ID, true);
+        Assert.assertEquals(300, response.getStatus());
+        verify(this.repository, never()).create();
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientUserHasNoEditAccessThrowsWebApplicationException()
+    {
+        try {
+            when(this.access.hasAccess(this.currentUser, Right.EDIT, this.patientReference)).thenReturn(false);
+            this.component.patchPatient(EMPTY_JSON, LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.FORBIDDEN.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientInvalidJsonThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient("[]", LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientIdFromJsonAndRetrievedPatientIdConflictThrowsWebApplicationException()
+    {
+        try {
+            this.component.patchPatient("{\"id\":\"wrong\"}", LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.CONFLICT.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void patchPatientUpdatingPatientFromJsonFailsResultsInWebApplicationException()
+    {
+        try {
+            doThrow(new RuntimeException()).when(this.patient).updateFromJSON(any(JSONObject.class),
+                eq(PatientWritePolicy.MERGE));
+            this.component.patchPatient(EMPTY_JSON, LABEL, EID, true);
+        } catch (final WebApplicationException ex) {
+            Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), ex.getResponse().getStatus());
+            throw ex;
+        }
+    }
+
+    @Test
+    public void patchPatientUpdatesPatientSuccessfully()
+    {
+        final Response response = this.component.patchPatient(EMPTY_JSON, LABEL, EID, true);
+        verify(this.patient, times(1)).updateFromJSON(any(JSONObject.class), eq(PatientWritePolicy.MERGE));
+        Assert.assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    /**
+     * For a given label and its corresponding id value (fields on {@code LabeledIdentifierClass} objects), query
+     * patient documents.
+     *
+     * @param label the name of the label
+     * @param id the id value for the label
+     * @return an empty list if no patients have the label identifier and its corresponding id value, else a list of
+     *         patient internal identifiers
+     * @throws Exception if there is any error during querying
+     */
+    private Patient getPatientByLabelAndEid(String label, String id)
+    {
+        try {
+            Query q = this.qm.createQuery(
+                "select doc.name from Document doc, doc.object(PhenoTips.LabeledIdentifierClass) obj "
+                + "where obj.label = :label and obj.value = :value", Query.XWQL);
+            q.bindValue(KEY_LABEL, label);
+            q.bindValue(KEY_VALUE, id);
+            List<String> results = q.execute();
+            if (results.size() == 1) {
+                DocumentReference reference =
+                    this.stringResolver.resolve(results.get(0), Patient.DEFAULT_DATA_SPACE);
+                return new PhenoTipsPatient((XWikiDocument) this.bridge.getDocument(reference));
+            }
+        } catch (QueryException ex) {
+            this.logger.warn("Failed to query patient documents with label [{}] and corresponding external ID [{}]: {}",
+                label, id, ex.getMessage(), ex);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+}

--- a/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/VocabularyTermResource.java
+++ b/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/VocabularyTermResource.java
@@ -45,7 +45,7 @@ public interface VocabularyTermResource
      * Retrieves a JSON representation of the {@link org.phenotips.vocabulary.VocabularyTerm} by searching the specified
      * vocabulary.
      *
-     * @param vocabularyId the vocabulary identifier, whic  h is also used as a prefix in every term identifier from that
+     * @param vocabularyId the vocabulary identifier, which is also used as a prefix in every term identifier from that
      *            vocabulary, for example {@code HP} or {@code MIM}
      * @param termId the term identifier, in the format {@code <vocabulary prefix>:<term id>}, for example
      *            {@code HP:0002066}

--- a/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/VocabularyTermResource.java
+++ b/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/VocabularyTermResource.java
@@ -45,7 +45,7 @@ public interface VocabularyTermResource
      * Retrieves a JSON representation of the {@link org.phenotips.vocabulary.VocabularyTerm} by searching the specified
      * vocabulary.
      *
-     * @param vocabularyId the vocabulary identifier, which is also used as a prefix in every term identifier from that
+     * @param vocabularyId the vocabulary identifier, whic  h is also used as a prefix in every term identifier from that
      *            vocabulary, for example {@code HP} or {@code MIM}
      * @param termId the term identifier, in the format {@code <vocabulary prefix>:<term id>}, for example
      *            {@code HP:0002066}


### PR DESCRIPTION
It behaves like the REST API for `external_id` with the exception of the `PUT` and `PATCH` methods. If there is no patient record that is identified by the given `label` and corresponding id `value`, a `404 Not Found` error is returned instead of creating a new patient record. This seems like better behaviour, is more defensive coding (i.e. less likely to break client applications), and allows for better integration with other systems. I had discussed this with Orion and Sebastian, and it was agreed that this behaviour would be more ideal. I would also suggest that these methods for `external_id`s also behave this way.