### PR TITLE
PT-3565: Variants cannot be deleted via the REST patient API

### DIFF
--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/VariantListController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/VariantListController.java
@@ -391,11 +391,7 @@ public class VariantListController extends AbstractComplexController<Map<String,
                 variantSymbols.add(variantJson.getString(INTERNAL_VARIANT_KEY));
             }
 
-            if (allVariants.isEmpty()) {
-                return null;
-            } else {
-                return new IndexedPatientData<>(getName(), allVariants);
-            }
+            return new IndexedPatientData<>(getName(), allVariants);
         } catch (Exception e) {
             this.logger.error("Could not load variants from JSON", e.getMessage());
         }


### PR DESCRIPTION
Sending an empty array for the variants key in a REST PUT request should empty the list of variants.