### PR TITLE
PT-3623: Allow new vocabularies to be installed as extensions

### DIFF
--- a/components/phenotype-suggest-service/api/src/main/java/org/phenotips/diagnosis/differentialPhenotypes/PhenotypeSuggestService.java
+++ b/components/phenotype-suggest-service/api/src/main/java/org/phenotips/diagnosis/differentialPhenotypes/PhenotypeSuggestService.java
@@ -64,6 +64,11 @@ public class PhenotypeSuggestService implements ScriptService
     @Named("hpo")
     private Vocabulary hpo;
 
+    /** Provides access to the OMIM ontology. */
+    @Inject
+    @Named("omim")
+    private Vocabulary omim;
+
     @Inject
     private SolrVocabularyResourceManager solrManager;
 
@@ -86,7 +91,7 @@ public class PhenotypeSuggestService implements ScriptService
         QueryResponse response;
         List<SuggestedPhenotype> result = new LinkedList<>();
         try {
-            response = this.solrManager.getSolrConnection("omim").query(prepareParams(phenotypes, nphenotypes));
+            response = this.solrManager.getSolrConnection(this.omim).query(prepareParams(phenotypes, nphenotypes));
         } catch (SolrServerException | IOException ex) {
             this.logger.warn("Failed to query OMIM index: {}", ex.getMessage());
             return result;

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/SolrVocabularyResourceManager.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/SolrVocabularyResourceManager.java
@@ -37,55 +37,55 @@ public interface SolrVocabularyResourceManager
     /**
      * Get the cache instance created for handling vocabulary terms.
      *
-     * @param vocabularyId the identifier of the target vocabulary
+     * @param vocabulary the target vocabulary
      * @return a cache instance
      */
-    Cache<VocabularyTerm> getTermCache(String vocabularyId);
+    Cache<VocabularyTerm> getTermCache(Vocabulary vocabulary);
 
     /**
      * Get the Solr core used for a vocabulary.
      *
-     * @param vocabularyId the identifier of the target vocabulary
+     * @param vocabulary the target vocabulary
      * @return a Solr client for communication with the target core
      */
-    SolrClient getSolrConnection(String vocabularyId);
+    SolrClient getSolrConnection(Vocabulary vocabulary);
 
     /**
      * Copy the Solr configuration file in a separate temporary directory, then register this temporary core with the
-     * Solr server. This core can be accessed with {@link #getReplacementSolrConnection(String)} during reindexing, and
-     * then it can either be discarded with {@link #discardReplacementCore(String)}, or take the place of the
-     * {@link #getSolrConnection(String) official vocabulary index} with {@link #replaceCore(String)}.
+     * Solr server. This core can be accessed with {@link #getReplacementSolrConnection(Vocabulary)} during reindexing,
+     * and then it can either be discarded with {@link #discardReplacementCore(Vocabulary)}, or take the place of the
+     * {@link #getSolrConnection(Vocabulary) official vocabulary index} with {@link #replaceCore(Vocabulary)}.
      *
-     * @param vocabularyId the identifier of the target vocabulary
+     * @param vocabulary the target vocabulary
      * @throws InitializationException if the process fails
      * @since 1.4
      */
-    void createReplacementCore(String vocabularyId) throws InitializationException;
+    void createReplacementCore(Vocabulary vocabulary) throws InitializationException;
 
     /**
      * Copy new index data from the temporary core to the main index location.
      *
-     * @param vocabularyId the identifier of the target vocabulary
+     * @param vocabulary the target vocabulary
      * @throws InitializationException if the process fails
      * @since 1.4
      */
-    void replaceCore(String vocabularyId) throws InitializationException;
+    void replaceCore(Vocabulary vocabulary) throws InitializationException;
 
     /**
      * Get the temporary Solr core used for a vocabulary during reindexing.
      *
-     * @param vocabularyId the identifier of the target vocabulary
+     * @param vocabulary the identifier of the target vocabulary
      * @return a Solr client for communication with the target temporary core
      * @since 1.4
      */
-    SolrClient getReplacementSolrConnection(String vocabularyId);
+    SolrClient getReplacementSolrConnection(Vocabulary vocabulary);
 
     /**
-     * Delete the temporary core, if one was already created by {@link #createReplacementCore(String)}. If no temporary
-     * core was created, nothing happens.
+     * Delete the temporary core, if one was already created by {@link #createReplacementCore(Vocabulary)}. If no
+     * temporary core was created, nothing happens.
      *
-     * @param vocabularyId the identifier of the target vocabulary
+     * @param vocabulary the target vocabulary
      * @since 1.4
      */
-    void discardReplacementCore(String vocabularyId);
+    void discardReplacementCore(Vocabulary vocabulary);
 }

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/ContextVocabularyMapProvider.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/ContextVocabularyMapProvider.java
@@ -1,0 +1,59 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.vocabulary.internal;
+
+import org.phenotips.vocabulary.Vocabulary;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+
+import java.util.Collections;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+/**
+ * This provides a map of all the {@link Vocabulary} instances visible in the current context. This class shouldn't be
+ * needed, but the generic provider from the XWiki core only looks up in the global context, which doesn't take into
+ * account vocabularies installed in only one wiki instance.
+ *
+ * @version $Id$
+ * @since 1.4
+ */
+@Component
+@Singleton
+public class ContextVocabularyMapProvider implements Provider<Map<String, Vocabulary>>
+{
+    @Inject
+    @Named("context")
+    private Provider<ComponentManager> cm;
+
+    @Override
+    public Map<String, Vocabulary> get()
+    {
+        try {
+            return this.cm.get().getInstanceMap(Vocabulary.class);
+        } catch (ComponentLookupException e) {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractCSVSolrVocabulary.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractCSVSolrVocabulary.java
@@ -116,7 +116,7 @@ public abstract class AbstractCSVSolrVocabulary extends AbstractSolrVocabulary
     protected int clear()
     {
         try {
-            this.externalServicesAccess.getSolrConnection(getCoreName()).deleteByQuery("*:*");
+            this.externalServicesAccess.getSolrConnection(this).deleteByQuery("*:*");
             return 0;
         } catch (SolrServerException ex) {
             this.logger.error("SolrServerException while clearing the Solr index", ex);
@@ -139,7 +139,7 @@ public abstract class AbstractCSVSolrVocabulary extends AbstractSolrVocabulary
         }
 
         try {
-            response = this.externalServicesAccess.getSolrConnection(getCoreName()).query(query);
+            response = this.externalServicesAccess.getSolrConnection(this).query(query);
             termList = response.getResults();
 
             if (termList != null && !termList.isEmpty()) {
@@ -165,7 +165,7 @@ public abstract class AbstractCSVSolrVocabulary extends AbstractSolrVocabulary
         query.setQuery("version:*");
         query.set(CommonParams.ROWS, "1");
         try {
-            response = this.externalServicesAccess.getSolrConnection(getCoreName()).query(query);
+            response = this.externalServicesAccess.getSolrConnection(this).query(query);
             termList = response.getResults();
 
             if (!termList.isEmpty()) {

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOBOSolrVocabulary.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOBOSolrVocabulary.java
@@ -151,7 +151,7 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
     protected int clear()
     {
         try {
-            this.externalServicesAccess.getSolrConnection(getCoreName()).deleteByQuery("*:*");
+            this.externalServicesAccess.getSolrConnection(this).deleteByQuery("*:*");
             return 0;
         } catch (SolrServerException ex) {
             this.logger.error("SolrServerException while clearing the Solr index", ex);
@@ -172,7 +172,7 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
         query.setQuery("version:*");
         query.set("rows", "1");
         try {
-            response = this.externalServicesAccess.getSolrConnection(getCoreName()).query(query);
+            response = this.externalServicesAccess.getSolrConnection(this).query(query);
             termList = response.getResults();
 
             if (!termList.isEmpty()) {

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOWLSolrVocabulary.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOWLSolrVocabulary.java
@@ -103,7 +103,7 @@ public abstract class AbstractOWLSolrVocabulary extends AbstractSolrVocabulary
     protected int clear()
     {
         try {
-            this.externalServicesAccess.getSolrConnection(getCoreName()).deleteByQuery("*:*");
+            this.externalServicesAccess.getSolrConnection(this).deleteByQuery("*:*");
             return 0;
         } catch (SolrServerException ex) {
             this.logger.error("SolrServerException while clearing the Solr index", ex);
@@ -190,7 +190,7 @@ public abstract class AbstractOWLSolrVocabulary extends AbstractSolrVocabulary
         query.setQuery("version:*");
         query.set(CommonParams.ROWS, "1");
         try {
-            final QueryResponse response = this.externalServicesAccess.getSolrConnection(getCoreName()).query(query);
+            final QueryResponse response = this.externalServicesAccess.getSolrConnection(this).query(query);
             final SolrDocumentList termList = response.getResults();
 
             if (!termList.isEmpty()) {
@@ -218,7 +218,7 @@ public abstract class AbstractOWLSolrVocabulary extends AbstractSolrVocabulary
         if (StringUtils.isNotBlank(version)) {
             doc.addField(ID_FIELD_NAME, HEADER_INFO_LABEL);
             doc.addField(VERSION_FIELD_NAME, version);
-            this.externalServicesAccess.getSolrConnection(getCoreName()).add(doc);
+            this.externalServicesAccess.getSolrConnection(this).add(doc);
             doc.clear();
         }
     }

--- a/components/vocabularies/api/src/main/resources/META-INF/components.txt
+++ b/components/vocabularies/api/src/main/resources/META-INF/components.txt
@@ -1,3 +1,4 @@
+org.phenotips.vocabulary.internal.ContextVocabularyMapProvider
 org.phenotips.vocabulary.internal.DefaultVocabularyManager
 org.phenotips.vocabulary.script.OntologyScriptService
 org.phenotips.vocabulary.script.VocabularyScriptService

--- a/components/vocabularies/api/src/test/java/org/phenotips/vocabulary/internal/ContextVocabularyMapProviderTest.java
+++ b/components/vocabularies/api/src/test/java/org/phenotips/vocabulary/internal/ContextVocabularyMapProviderTest.java
@@ -1,0 +1,95 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.vocabulary.internal;
+
+import org.phenotips.vocabulary.Vocabulary;
+
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Provider;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+/**
+ * Test for the {@link ContextVocabularyMapProvider} component.
+ *
+ * @version $Id$
+ */
+public class ContextVocabularyMapProviderTest
+{
+    @Rule
+    public MockitoComponentMockingRule<Provider<Map<String, Vocabulary>>> mocker =
+        new MockitoComponentMockingRule<>(ContextVocabularyMapProvider.class);
+
+    @Mock
+    private Vocabulary vocabulary1;
+
+    @Mock
+    private Vocabulary vocabulary2;
+
+    @Mock
+    private Vocabulary vocabulary3;
+
+    private ComponentManager componentManager;
+
+    private Map<String, Vocabulary> vocabularies;
+
+    @Before
+    public void setup() throws Exception
+    {
+        MockitoAnnotations.initMocks(this);
+
+        this.vocabularies = new HashMap<>();
+        this.vocabularies.put("v1", this.vocabulary1);
+        this.vocabularies.put("v2", this.vocabulary2);
+        this.vocabularies.put("v3", this.vocabulary3);
+        this.componentManager = this.mocker.getInstance(ComponentManager.class, "context");
+        doReturn(this.vocabularies).when(this.componentManager).getInstanceMap(Vocabulary.class);
+    }
+
+    @Test
+    public void allVocabulariesAreReturned() throws ComponentLookupException
+    {
+        Map<String, Vocabulary> result = this.mocker.getComponentUnderTest().get();
+        Assert.assertEquals(3, result.size());
+        Assert.assertSame(this.vocabulary1, result.get("v1"));
+        Assert.assertSame(this.vocabulary2, result.get("v2"));
+        Assert.assertSame(this.vocabulary3, result.get("v3"));
+    }
+
+    @Test
+    public void componentLookupExceptionIsCaughtAndEmptyMapIsReturned() throws ComponentLookupException
+    {
+        doThrow(new ComponentLookupException("test")).when(this.componentManager).getInstanceMap(
+            Vocabulary.class);
+        Assert.assertTrue(this.mocker.getComponentUnderTest().get().isEmpty());
+    }
+}

--- a/components/vocabularies/api/src/test/java/org/phenotips/vocabulary/internal/DefaultVocabularyManagerTest.java
+++ b/components/vocabularies/api/src/test/java/org/phenotips/vocabulary/internal/DefaultVocabularyManagerTest.java
@@ -50,8 +50,6 @@ import static org.mockito.Mockito.when;
  */
 public class DefaultVocabularyManagerTest
 {
-    private static final String VOCABULARIES_LABEL = "vocabularies";
-
     private static final String CHEMICAL_CATEGORY = "chemical";
 
     private static final String ETHNICITY_CATEGORY = "ethnicity";

--- a/components/vocabularies/chebi/api/src/main/java/org/phenotips/vocabulary/internal/solr/ChEBIOntology.java
+++ b/components/vocabularies/chebi/api/src/main/java/org/phenotips/vocabulary/internal/solr/ChEBIOntology.java
@@ -50,12 +50,6 @@ public class ChEBIOntology extends AbstractOBOSolrVocabulary
     }
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public String getDefaultSourceLocation()
     {
         return "ftp://ftp.ebi.ac.uk/pub/databases/chebi/ontology/chebi.obo";

--- a/components/vocabularies/chebi/api/src/test/java/org/phenotips/vocabulary/internal/solr/ChEBIOntologyTest.java
+++ b/components/vocabularies/chebi/api/src/test/java/org/phenotips/vocabulary/internal/solr/ChEBIOntologyTest.java
@@ -62,7 +62,7 @@ public class ChEBIOntologyTest
 
     private SolrClient server;
 
-    private Vocabulary ontologyService;
+    private Vocabulary vocabulary;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -70,15 +70,15 @@ public class ChEBIOntologyTest
         throws ComponentLookupException, IOException, SolrServerException, CacheException
     {
         this.cache = mock(Cache.class);
+        this.vocabulary = this.mocker.getComponentUnderTest();
         SolrVocabularyResourceManager externalServicesAccess =
             this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(externalServicesAccess.getTermCache("chebi")).thenReturn(this.cache);
+        when(externalServicesAccess.getTermCache(this.vocabulary)).thenReturn(this.cache);
         this.server = mock(SolrClient.class);
-        when(externalServicesAccess.getReplacementSolrConnection("chebi")).thenReturn(this.server);
-        when(externalServicesAccess.getSolrConnection("chebi")).thenReturn(this.server);
-        this.ontologyService = this.mocker.getComponentUnderTest();
+        when(externalServicesAccess.getReplacementSolrConnection(this.vocabulary)).thenReturn(this.server);
+        when(externalServicesAccess.getSolrConnection(this.vocabulary)).thenReturn(this.server);
         this.ontologyServiceResult =
-            this.ontologyService.reindex(this.getClass().getResource("/chebi-test.obo").toString());
+            this.vocabulary.reindex(this.getClass().getResource("/chebi-test.obo").toString());
     }
 
     @Test
@@ -103,13 +103,13 @@ public class ChEBIOntologyTest
         SolrDocument versionDoc = mock(SolrDocument.class);
         when(results.get(0)).thenReturn(versionDoc);
         when(versionDoc.getFieldValue("version")).thenReturn("2014:01:01");
-        Assert.assertEquals("2014:01:01", this.ontologyService.getVersion());
+        Assert.assertEquals("2014:01:01", this.vocabulary.getVersion());
     }
 
     @Test
     public void testChEBIOntologyDefaultLocation()
     {
-        String location = this.ontologyService.getDefaultSourceLocation();
+        String location = this.vocabulary.getDefaultSourceLocation();
         Assert.assertNotNull(location);
         Assert.assertTrue(location.endsWith("chebi.obo"));
         Assert.assertTrue(location.startsWith("ftp"));

--- a/components/vocabularies/ethnicity/api/src/main/java/org/phenotips/vocabulary/internal/solr/EthnicityOntology.java
+++ b/components/vocabularies/ethnicity/api/src/main/java/org/phenotips/vocabulary/internal/solr/EthnicityOntology.java
@@ -91,12 +91,6 @@ public class EthnicityOntology extends AbstractSolrVocabulary
     }
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public String getIdentifier()
     {
         return "ethnicity";

--- a/components/vocabularies/hgnc/api/src/main/java/org/phenotips/vocabulary/internal/solr/GeneNomenclature.java
+++ b/components/vocabularies/hgnc/api/src/main/java/org/phenotips/vocabulary/internal/solr/GeneNomenclature.java
@@ -140,12 +140,6 @@ public class GeneNomenclature extends AbstractCSVSolrVocabulary
     }
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public String getIdentifier()
     {
         return "hgnc";

--- a/components/vocabularies/hgnc/api/src/test/java/org/phenotips/vocabulary/internal/solr/GeneNomenclatureTest.java
+++ b/components/vocabularies/hgnc/api/src/test/java/org/phenotips/vocabulary/internal/solr/GeneNomenclatureTest.java
@@ -55,8 +55,6 @@ public class GeneNomenclatureTest
 {
     private static final String IDENTIFIER = "hgnc";
 
-    private static final String CORE_NAME = IDENTIFIER;
-
     private static final String NAME = "HUGO Gene Nomenclature Committee's GeneNames (HGNC)";
 
     private static final String WEBSITE = "http://www.genenames.org/";
@@ -117,7 +115,7 @@ public class GeneNomenclatureTest
 
         final SolrVocabularyResourceManager externalServicesAccess =
             this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(externalServicesAccess.getSolrConnection(CORE_NAME)).thenReturn(this.solrClient);
+        when(externalServicesAccess.getSolrConnection(this.component)).thenReturn(this.solrClient);
 
         when(this.solrClient.query(any(SolrQuery.class))).thenReturn(this.response);
         when(this.response.getResults()).thenReturn(this.termList);
@@ -140,13 +138,6 @@ public class GeneNomenclatureTest
     {
         final int numDocs = this.component.getSolrDocsPerBatch();
         Assert.assertEquals(NUM_DOCS, numDocs);
-    }
-
-    @Test
-    public void getCoreNameReturnsCorrectName()
-    {
-        final String coreName = this.component.getCoreName();
-        Assert.assertEquals(CORE_NAME, coreName);
     }
 
     @Test

--- a/components/vocabularies/hpo/api/src/main/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntology.java
+++ b/components/vocabularies/hpo/api/src/main/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntology.java
@@ -72,12 +72,6 @@ public class HumanPhenotypeOntology extends AbstractOBOSolrVocabulary
     private static final String DEFAULT_QUALIFIER_FILTER = "term_category:HP\\:0012823";
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public String getDefaultSourceLocation()
     {
         return "https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo";

--- a/components/vocabularies/hpo/api/src/test/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntologyTest.java
+++ b/components/vocabularies/hpo/api/src/test/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntologyTest.java
@@ -79,10 +79,10 @@ public class HumanPhenotypeOntologyTest
         this.vocabulary = this.mocker.getComponentUnderTest();
         SolrVocabularyResourceManager externalServicesAccess =
             this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(externalServicesAccess.getTermCache("hpo")).thenReturn(this.cache);
+        when(externalServicesAccess.getTermCache(this.vocabulary)).thenReturn(this.cache);
         this.server = mock(SolrClient.class);
-        when(externalServicesAccess.getReplacementSolrConnection("hpo")).thenReturn(this.server);
-        when(externalServicesAccess.getSolrConnection("hpo")).thenReturn(this.server);
+        when(externalServicesAccess.getReplacementSolrConnection(this.vocabulary)).thenReturn(this.server);
+        when(externalServicesAccess.getSolrConnection(this.vocabulary)).thenReturn(this.server);
         this.ontologyServiceResult =
             this.vocabulary.reindex(this.getClass().getResource("/hpo-test.obo").toString());
     }

--- a/components/vocabularies/hpo/api/src/test/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntologyTest.java
+++ b/components/vocabularies/hpo/api/src/test/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntologyTest.java
@@ -68,7 +68,7 @@ public class HumanPhenotypeOntologyTest
 
     private SolrClient server;
 
-    private Vocabulary ontologyService;
+    private Vocabulary vocabulary;
 
     @SuppressWarnings("unchecked")
     @Before
@@ -76,15 +76,15 @@ public class HumanPhenotypeOntologyTest
         throws ComponentLookupException, IOException, SolrServerException, CacheException
     {
         this.cache = mock(Cache.class);
+        this.vocabulary = this.mocker.getComponentUnderTest();
         SolrVocabularyResourceManager externalServicesAccess =
             this.mocker.getInstance(SolrVocabularyResourceManager.class);
         when(externalServicesAccess.getTermCache("hpo")).thenReturn(this.cache);
         this.server = mock(SolrClient.class);
         when(externalServicesAccess.getReplacementSolrConnection("hpo")).thenReturn(this.server);
         when(externalServicesAccess.getSolrConnection("hpo")).thenReturn(this.server);
-        this.ontologyService = this.mocker.getComponentUnderTest();
         this.ontologyServiceResult =
-            this.ontologyService.reindex(this.getClass().getResource("/hpo-test.obo").toString());
+            this.vocabulary.reindex(this.getClass().getResource("/hpo-test.obo").toString());
     }
 
     @Test
@@ -109,13 +109,13 @@ public class HumanPhenotypeOntologyTest
         SolrDocument versionDoc = mock(SolrDocument.class);
         when(results.get(0)).thenReturn(versionDoc);
         when(versionDoc.getFieldValue("version")).thenReturn("2014:01:01");
-        Assert.assertEquals("2014:01:01", this.ontologyService.getVersion());
+        Assert.assertEquals("2014:01:01", this.vocabulary.getVersion());
     }
 
     @Test
     public void testHumanPhenotypeOntologyDefaultLocation()
     {
-        String location = this.ontologyService.getDefaultSourceLocation();
+        String location = this.vocabulary.getDefaultSourceLocation();
         Assert.assertNotNull(location);
         Assert.assertTrue(location.endsWith("hp.obo"));
         Assert.assertTrue(location.startsWith("http"));

--- a/components/vocabularies/hpo/translation-french/src/test/java/org/phenotips/vocabulary/internal/solr/FrenchHPOTranslationTest.java
+++ b/components/vocabularies/hpo/translation-french/src/test/java/org/phenotips/vocabulary/internal/solr/FrenchHPOTranslationTest.java
@@ -96,7 +96,7 @@ public class FrenchHPOTranslationTest
         MockitoAnnotations.initMocks(this);
 
         SolrVocabularyResourceManager solrManager = this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(solrManager.getSolrConnection(any(String.class))).thenReturn(this.solrClient);
+        when(solrManager.getSolrConnection(any(Vocabulary.class))).thenReturn(this.solrClient);
         when(this.solrClient.request(Matchers.argThat(this.coreRequests), any())).thenReturn(new NamedList<>());
 
         this.localizationContext = this.mocker.getInstance(LocalizationContext.class);

--- a/components/vocabularies/hpo/translation-german/src/test/java/org/phenotips/vocabulary/internal/solr/GermanHPOTranslationTest.java
+++ b/components/vocabularies/hpo/translation-german/src/test/java/org/phenotips/vocabulary/internal/solr/GermanHPOTranslationTest.java
@@ -96,7 +96,7 @@ public class GermanHPOTranslationTest
         MockitoAnnotations.initMocks(this);
 
         SolrVocabularyResourceManager solrManager = this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(solrManager.getSolrConnection(any(String.class))).thenReturn(this.solrClient);
+        when(solrManager.getSolrConnection(any(Vocabulary.class))).thenReturn(this.solrClient);
         when(this.solrClient.request(Matchers.argThat(this.coreRequests), any())).thenReturn(new NamedList<>());
 
         this.localizationContext = this.mocker.getInstance(LocalizationContext.class);

--- a/components/vocabularies/hpo/translation-italian/src/test/java/org/phenotips/vocabulary/internal/solr/ItalianHPOTranslationTest.java
+++ b/components/vocabularies/hpo/translation-italian/src/test/java/org/phenotips/vocabulary/internal/solr/ItalianHPOTranslationTest.java
@@ -96,7 +96,7 @@ public class ItalianHPOTranslationTest
         MockitoAnnotations.initMocks(this);
 
         SolrVocabularyResourceManager solrManager = this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(solrManager.getSolrConnection(any(String.class))).thenReturn(this.solrClient);
+        when(solrManager.getSolrConnection(any(Vocabulary.class))).thenReturn(this.solrClient);
         when(this.solrClient.request(Matchers.argThat(this.coreRequests), any())).thenReturn(new NamedList<>());
 
         this.localizationContext = this.mocker.getInstance(LocalizationContext.class);

--- a/components/vocabularies/hpo/translation-russian/src/test/java/org/phenotips/vocabulary/internal/solr/RussianHPOTranslationTest.java
+++ b/components/vocabularies/hpo/translation-russian/src/test/java/org/phenotips/vocabulary/internal/solr/RussianHPOTranslationTest.java
@@ -96,7 +96,7 @@ public class RussianHPOTranslationTest
         MockitoAnnotations.initMocks(this);
 
         SolrVocabularyResourceManager solrManager = this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(solrManager.getSolrConnection(any(String.class))).thenReturn(this.solrClient);
+        when(solrManager.getSolrConnection(any(Vocabulary.class))).thenReturn(this.solrClient);
         when(this.solrClient.request(Matchers.argThat(this.coreRequests), any())).thenReturn(new NamedList<>());
 
         this.localizationContext = this.mocker.getInstance(LocalizationContext.class);

--- a/components/vocabularies/hpo/translation-spanish/src/test/java/org/phenotips/vocabulary/internal/solr/SpanishHPOTranslationTest.java
+++ b/components/vocabularies/hpo/translation-spanish/src/test/java/org/phenotips/vocabulary/internal/solr/SpanishHPOTranslationTest.java
@@ -96,7 +96,7 @@ public class SpanishHPOTranslationTest
         MockitoAnnotations.initMocks(this);
 
         SolrVocabularyResourceManager solrManager = this.mocker.getInstance(SolrVocabularyResourceManager.class);
-        when(solrManager.getSolrConnection(any(String.class))).thenReturn(this.solrClient);
+        when(solrManager.getSolrConnection(any(Vocabulary.class))).thenReturn(this.solrClient);
         when(this.solrClient.request(Matchers.argThat(this.coreRequests), any())).thenReturn(new NamedList<>());
 
         this.localizationContext = this.mocker.getInstance(LocalizationContext.class);

--- a/components/vocabularies/omim/api/src/main/java/org/phenotips/vocabulary/internal/solr/MendelianInheritanceInMan.java
+++ b/components/vocabularies/omim/api/src/main/java/org/phenotips/vocabulary/internal/solr/MendelianInheritanceInMan.java
@@ -160,12 +160,6 @@ public class MendelianInheritanceInMan extends AbstractCSVSolrVocabulary
     }
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public List<VocabularyTerm> search(String input, String category, int maxResults, String sort, String customFilter)
     {
         if (!getSupportedCategories().contains(category)) {

--- a/components/vocabularies/oncotree/api/src/main/java/org/phenotips/vocabulary/internal/solr/OncoTree.java
+++ b/components/vocabularies/oncotree/api/src/main/java/org/phenotips/vocabulary/internal/solr/OncoTree.java
@@ -371,12 +371,6 @@ public class OncoTree extends AbstractCSVSolrVocabulary
     }
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public String getIdentifier()
     {
         return "onco";

--- a/components/vocabularies/oncotree/api/src/main/java/org/phenotips/vocabulary/internal/solr/OncoTree.java
+++ b/components/vocabularies/oncotree/api/src/main/java/org/phenotips/vocabulary/internal/solr/OncoTree.java
@@ -195,7 +195,7 @@ public class OncoTree extends AbstractCSVSolrVocabulary
             doc.addField(fieldName, fieldValue);
         } else {
             this.logger.error("The field name {} and field value {} being processed are not associated with any "
-                    + "cancer.", fieldName, fieldValue);
+                + "cancer.", fieldName, fieldValue);
         }
     }
 
@@ -228,6 +228,7 @@ public class OncoTree extends AbstractCSVSolrVocabulary
 
     /**
      * Update the {@code doc} with the {@code tissue} associated with it.
+     *
      * @param doc the {@link SolrInputDocument} containing cancer data
      * @param tissue the tissue affected by the cancer
      */
@@ -302,7 +303,7 @@ public class OncoTree extends AbstractCSVSolrVocabulary
      *
      * @param doc the {@link SolrInputDocument} into which data is written
      * @param parent the {@link SolrInputDocument} that contains data for cancer that is a parent to the cancer stored
-     *               in {@code doc}
+     *            in {@code doc}
      */
     private void updateParents(@Nonnull final SolrInputDocument doc, @Nullable final SolrInputDocument parent)
     {
@@ -527,6 +528,7 @@ public class OncoTree extends AbstractCSVSolrVocabulary
 
     /**
      * Creates the version {@link SolrInputDocument}.
+     *
      * @param url the {@link URL} where data is stored
      * @return a {@link SolrInputDocument} containing version data
      */

--- a/components/vocabularies/oncotree/api/src/test/java/org/phenotips/vocabulary/internal/solr/OncoTreeTest.java
+++ b/components/vocabularies/oncotree/api/src/test/java/org/phenotips/vocabulary/internal/solr/OncoTreeTest.java
@@ -180,13 +180,13 @@ public class OncoTreeTest
     {
         MockitoAnnotations.initMocks(this);
 
+        this.component = this.mocker.getComponentUnderTest();
+        this.oncoTree = spy((OncoTree) this.component);
+
         SolrVocabularyResourceManager externalServicesAccess =
             this.mocker.getInstance(SolrVocabularyResourceManager.class);
 
-        when(externalServicesAccess.getSolrConnection(ONCO_LOWER)).thenReturn(this.server);
-
-        this.component = this.mocker.getComponentUnderTest();
-        this.oncoTree = spy((OncoTree) this.component);
+        when(externalServicesAccess.getSolrConnection(this.component)).thenReturn(this.server);
 
         this.logger = this.mocker.getMockedLogger();
         this.url = new URL(this.component.getDefaultSourceLocation());
@@ -364,12 +364,6 @@ public class OncoTreeTest
                     Assert.fail();
             }
         }
-    }
-
-    @Test
-    public void getCoreName()
-    {
-        Assert.assertEquals(ONCO_LOWER, ((OncoTree) this.component).getCoreName());
     }
 
     @Test

--- a/components/vocabularies/oncotree/api/src/test/java/org/phenotips/vocabulary/internal/solr/OncoTreeTest.java
+++ b/components/vocabularies/oncotree/api/src/test/java/org/phenotips/vocabulary/internal/solr/OncoTreeTest.java
@@ -422,7 +422,7 @@ public class OncoTreeTest
         Assert.assertTrue(categories.contains(DISEASE));
     }
 
-    @Test (expected = UnsupportedOperationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void getSupportedCategoriesReturnsImmutableCollection()
     {
         final Collection<String> categories = this.component.getSupportedCategories();

--- a/components/vocabularies/ordo/api/src/main/java/org/phenotips/vocabulary/internal/solr/OrphanetRareDiseaseOntology.java
+++ b/components/vocabularies/ordo/api/src/main/java/org/phenotips/vocabulary/internal/solr/OrphanetRareDiseaseOntology.java
@@ -120,12 +120,6 @@ public class OrphanetRareDiseaseOntology extends AbstractOWLSolrVocabulary
     }
 
     @Override
-    protected String getCoreName()
-    {
-        return getIdentifier();
-    }
-
-    @Override
     public Set<String> getAliases()
     {
         final Set<String> aliases = new HashSet<>();

--- a/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/internal/DefaultVocabularyResource.java
+++ b/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/internal/DefaultVocabularyResource.java
@@ -136,7 +136,7 @@ public class DefaultVocabularyResource extends XWikiResource implements Vocabula
         // Validate URL before loading any extensions
         String[] schemes = { "http", "https", "ftp", "file" };
         UrlValidator urlValidator = new UrlValidator(schemes);
-        if (!urlValidator.isValid(url) || !exists(url)) {
+        if (!url.startsWith("jar:") && (!urlValidator.isValid(url) || !exists(url))) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
 

--- a/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/internal/DefaultVocabularyResource.java
+++ b/components/vocabularies/rest/src/main/java/org/phenotips/vocabularies/rest/internal/DefaultVocabularyResource.java
@@ -136,7 +136,7 @@ public class DefaultVocabularyResource extends XWikiResource implements Vocabula
         // Validate URL before loading any extensions
         String[] schemes = { "http", "https", "ftp", "file" };
         UrlValidator urlValidator = new UrlValidator(schemes);
-        if (!url.startsWith("jar:") && (!urlValidator.isValid(url) || !exists(url))) {
+        if (url != null && !url.startsWith("jar:") && (!urlValidator.isValid(url) || !exists(url))) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
 

--- a/components/vocabularies/translations/xliff/src/main/java/org/phenotips/vocabulary/translation/AbstractXliffTranslatedSolrVocabularyExtension.java
+++ b/components/vocabularies/translations/xliff/src/main/java/org/phenotips/vocabulary/translation/AbstractXliffTranslatedSolrVocabularyExtension.java
@@ -19,6 +19,7 @@ package org.phenotips.vocabulary.translation;
 
 import org.phenotips.vocabulary.SolrVocabularyResourceManager;
 import org.phenotips.vocabulary.VocabularyExtension;
+import org.phenotips.vocabulary.VocabularyManager;
 
 import org.xwiki.component.phase.Initializable;
 
@@ -54,6 +55,9 @@ public abstract class AbstractXliffTranslatedSolrVocabularyExtension extends Abs
 {
     @Inject
     protected SolrVocabularyResourceManager coreConnection;
+
+    @Inject
+    private VocabularyManager vocabularyManager;
 
     @Override
     public void initialize()
@@ -148,7 +152,7 @@ public abstract class AbstractXliffTranslatedSolrVocabularyExtension extends Abs
      */
     protected SolrClient getClient()
     {
-        return this.coreConnection.getSolrConnection(getTargetVocabularyId());
+        return this.coreConnection.getSolrConnection(this.vocabularyManager.getVocabulary(getTargetVocabularyId()));
     }
 
     /**

--- a/components/vocabularies/ui/src/main/resources/PhenoTips/IndexVocabulary.xml
+++ b/components/vocabularies/ui/src/main/resources/PhenoTips/IndexVocabulary.xml
@@ -442,7 +442,7 @@ $xwiki.ssx.use('PhenoTips.Widgets')##
         // Create a notification message to display to the user when the submit is being sent
         form._x_notification = new XWiki.widgets.Notification("$!escapetool.javascript($services.localization.render('phenotips.indexVocabulary.inProgress'))", "inprogress");
         form.disable();
-        var vocabularyIndexURL = XWiki.contextPath + "/rest/vocabularies/" + vocabularyId + "?url=" + mandatoryElt.value;
+        var vocabularyIndexURL = XWiki.contextPath + "/rest/vocabularies/" + vocabularyId + "?url=" + encodeURIComponent(mandatoryElt.value);
         new Ajax.Request(vocabularyIndexURL, {
             method: 'post',
             onSuccess : function (response) {


### PR DESCRIPTION
Everything related to vocabularies must be tested, before and after reindexing:
- reindex
- redefine location
- search
- default phenotypes
- vocabulary browser ("browse related terms")

Also needs testing:
- clone care-pathways
- checkout branch CP-29
- build
- in phenotips, edit `webapps/phenotips/WEB-INF/xwiki.properties`
- add `extension.repositories=local:maven:file:///Path/To/UserHome/.m2/repository/` (use the right path)
- restart phenotips
- go to Administration -> Extension Manager -> Add Extension
- in the advanced search, type `org.webjars.npm:jquery` with version `3.3.1`, install it
- same place, type `org.phenotips:care-pathways-ui` with version `1.0-SNAPSHOT`, install it
- go to Administration -> Vocabularies, reindex the two care pathways vocabularies
- create a new patient, does Care Pathways work fine?
