### PR TITLE
Improve performance of "clear details" for phenotype metadata

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetMacros.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/PatientSheetMacros.xml
@@ -306,7 +306,7 @@
         &lt;dd class="${prop.name}${displayMode}"&gt;$doc.display($prop.getName(), $targetObj)&lt;/dd&gt;##
       #end##
     &lt;/dl&gt;##
-    &lt;input type="hidden" name="delete-action" value="$doc.getURL('objectremove', "classname=${targetObj.xWikiClass.name}&amp;amp;classid=${targetObj.number}&amp;amp;form_token=$!{services.csrf.getToken()}")"/&gt;##
+    &lt;input type="hidden" name="delete-action" value="$doc.getURL('objectremove', "classname=${targetObj.xWikiClass.name}&amp;amp;classid=${targetObj.number}&amp;amp;form_token=$!{services.csrf.getToken()}&amp;amp;ajax=1")"/&gt;##
     {{/html}}
 #end
 


### PR DESCRIPTION
Adding `ajax=1` to the request causes XWiki to return an HTTP 204
instead of redirecting to the full patient form