### PR TITLE
PT-3571: Resolve text mining issues and turn it on by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <jackson.fasterxml.version>2.8.6</jackson.fasterxml.version>
     <restlet.version>2.0.15</restlet.version>
     <buildtools.version>1.8</buildtools.version>
-    <textAnalysis.version>1.0-milestone-3</textAnalysis.version>
+    <textAnalysis.version>1.0-rc-1</textAnalysis.version>
     <testframework.version>1.1</testframework.version>
     <solr.version>6.5.1</solr.version>
     <jaxb2-fluent-api.version>3.0</jaxb2-fluent-api.version>


### PR DESCRIPTION
Not only that it doesn't crash, but it is actually a lot faster.