### PR TITLE
PT-3656: Pushing patient record and assigning it to one of user group does not work

### DIFF
--- a/components/patient-data-sharing/receiver-api/src/main/java/org/phenotips/data/receive/internal/DefaultReceivePatientData.java
+++ b/components/patient-data-sharing/receiver-api/src/main/java/org/phenotips/data/receive/internal/DefaultReceivePatientData.java
@@ -545,6 +545,8 @@ public class DefaultReceivePatientData implements ReceivePatientData
                 this.logger.warn("Created new patient successfully");
             }
 
+            // get updated saved instance of patient document
+            affectedPatient = this.patientRepository.get(affectedPatient.getDocument());
             JSONObject patientData = new JSONObject(patientJSON);
             affectedPatient.updateFromJSON(patientData);
 


### PR DESCRIPTION
Fixed by re-fetching patient document after the owner was updated