### PR TITLE
PT-3379: Families should support members that are not assigned to an individual in the pedigree

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
@@ -160,6 +160,17 @@ define([
                     alert(warningString);
                 }
 
+                // 3. add patients that are not in pedigree to the patient legend
+                var allLinkedNodes = editor.getGraph().getAllPatientLinks();
+                var allFamilyMembers = editor.getFamilyData().getAllFamilyMembersList()
+                for (var i = 0; i < allFamilyMembers.length; i++) {
+                    var nextMemberID = allFamilyMembers[i].id;
+                    if (!allLinkedNodes.patientToNodeMapping.hasOwnProperty(nextMemberID)) {
+                        editor.getPatientLegend().addCase(nextMemberID, {});
+                    }
+                }
+
+
                 if (!noUndo && !editor.isReadOnlyMode()) {
                     var undoRedoState = editor.getGraph().toUndoRedoState();
                     editor.getUndoRedoManager().addState({"eventName": eventName}, null, undoRedoState);

--- a/components/pedigree/resources/src/main/resources/pedigree/view.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view.js
@@ -777,7 +777,7 @@ define([
             if (changeSet.hasOwnProperty("unlinked")) {
                 for (var phenotipsID in changeSet.unlinked) {
                     if (changeSet.unlinked.hasOwnProperty(phenotipsID)) {
-                        editor.getPatientLegend().addCase(phenotipsID, {}, changeSet.unlinked[phenotipsID]);
+                        editor.getPatientLegend().addCase(phenotipsID, {});
                     }
                 }
             }


### PR DESCRIPTION
Added correct pedigree support for family members that were added to a family outside of pedigree editor
(and thus are not in pedigree even in "unlinked" form, e.g. via a data pull from CLIN)