### PR TITLE
PT-3674: When removing genes from a person in pedigree editor, all associated gene variants need to be removed too

### DIFF
--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/EmptyGenotypeObjectsRemover.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/EmptyGenotypeObjectsRemover.java
@@ -74,10 +74,11 @@ public class EmptyGenotypeObjectsRemover extends AbstractEventListener
         List<BaseObject> geneXWikiObjects = doc.getXObjects(Gene.GENE_CLASS);
         List<BaseObject> variantXWikiObjects = doc.getXObjects(VARIANT_CLASS_REFERENCE);
 
-        if ((geneXWikiObjects == null || geneXWikiObjects.isEmpty())
-            && (variantXWikiObjects != null && !variantXWikiObjects.isEmpty())) {
-            // delete all variants
-            doc.removeXObjects(VARIANT_CLASS_REFERENCE);
+        if (geneXWikiObjects == null || geneXWikiObjects.isEmpty()) {
+            if (variantXWikiObjects != null && !variantXWikiObjects.isEmpty()) {
+                // delete all variants
+                doc.removeXObjects(VARIANT_CLASS_REFERENCE);
+            }
             return;
         }
 


### PR DESCRIPTION
Fixed NPE if there are no genes and variants