### PR TITLE
PT-3812: Saving pedigrees fails when family members have medical reports attached

### DIFF
--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AdditionalDocumentsController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AdditionalDocumentsController.java
@@ -243,8 +243,10 @@ public class AdditionalDocumentsController implements PatientDataController<Atta
             return;
         }
 
+        boolean includeAttachmentContent = (selectedFieldNames != null);
+
         for (Attachment file : files) {
-            result.put(file.toJSON());
+            result.put(file.toJSON(includeAttachmentContent));
         }
         json.put(DATA_NAME, result);
     }
@@ -259,7 +261,10 @@ public class AdditionalDocumentsController implements PatientDataController<Atta
 
         JSONArray files = json.getJSONArray(DATA_NAME);
         for (Object file : files) {
-            result.add(this.adapter.fromJSON((JSONObject) file));
+            Attachment next = this.adapter.fromJSON((JSONObject) file);
+            if (next != null) {
+                result.add(next);
+            }
         }
 
         return new IndexedPatientData<>(getName(), result);

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AdditionalImagesController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AdditionalImagesController.java
@@ -249,8 +249,10 @@ public class AdditionalImagesController implements PatientDataController<Attachm
             return;
         }
 
+        boolean includeAttachmentContent = (selectedFieldNames != null);
+
         for (Attachment image : images) {
-            result.put(image.toJSON());
+            result.put(image.toJSON(includeAttachmentContent));
         }
         json.put(DATA_NAME, result);
     }
@@ -265,7 +267,10 @@ public class AdditionalImagesController implements PatientDataController<Attachm
 
         JSONArray images = json.getJSONArray(DATA_NAME);
         for (Object image : images) {
-            result.add(this.adapter.fromJSON((JSONObject) image));
+            Attachment next = this.adapter.fromJSON((JSONObject) image);
+            if (next != null) {
+                result.add(next);
+            }
         }
 
         return new IndexedPatientData<>(getName(), result);

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AttachmentAdapterFactory.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/AttachmentAdapterFactory.java
@@ -78,7 +78,7 @@ public class AttachmentAdapterFactory
      * Construct a new attachment adapter from a JSON-serialized attachment.
      *
      * @param attachment the attachment to deserialize
-     * @return a new adapter
+     * @return a new adapter, or null if provided JSON is not valid or does not include attachment content
      */
     public Attachment fromJSON(JSONObject attachment)
     {

--- a/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/MedicalReportsController.java
+++ b/components/patient-data/impl/src/main/java/org/phenotips/data/internal/controller/MedicalReportsController.java
@@ -234,8 +234,10 @@ public class MedicalReportsController implements PatientDataController<Attachmen
             return;
         }
 
+        boolean includeAttachmentContent = (selectedFieldNames != null);
+
         for (Attachment report : reports) {
-            result.put(report.toJSON());
+            result.put(report.toJSON(includeAttachmentContent));
         }
         json.put(DATA_NAME, result);
     }
@@ -250,7 +252,10 @@ public class MedicalReportsController implements PatientDataController<Attachmen
 
         JSONArray reports = json.getJSONArray(DATA_NAME);
         for (Object report : reports) {
-            result.add(this.adapter.fromJSON((JSONObject) report));
+            Attachment next = this.adapter.fromJSON((JSONObject) report);
+            if (next != null) {
+                result.add(next);
+            }
         }
 
         return new IndexedPatientData<>(getName(), result);

--- a/components/patient-data/impl/src/test/java/org/phenotips/data/internal/controller/AttachmentAdapterFactoryTest.java
+++ b/components/patient-data/impl/src/test/java/org/phenotips/data/internal/controller/AttachmentAdapterFactoryTest.java
@@ -188,7 +188,7 @@ public class AttachmentAdapterFactoryTest
         a1.addAttribute("boolkey", Boolean.FALSE);
         a1.addAttribute("boolkey", Boolean.TRUE);
         a1.addAttribute("numkey", Integer.valueOf(42));
-        JSONObject json1 = a1.toJSON();
+        JSONObject json1 = a1.toJSON(true);
 
         Assert.assertEquals("a1.pdf", json1.get(JSON_FIELD_FILENAME));
         Assert.assertEquals(4L, json1.get(JSON_FIELD_FILESIZE));
@@ -199,7 +199,7 @@ public class AttachmentAdapterFactoryTest
         Assert.assertEquals(true, json1.getBoolean("boolkey"));
         Assert.assertEquals(42, json1.getInt("numkey"));
 
-        JSONObject json2 = this.mocker.getComponentUnderTest().fromXWikiAttachment(this.attachment2).toJSON();
+        JSONObject json2 = this.mocker.getComponentUnderTest().fromXWikiAttachment(this.attachment2).toJSON(true);
         Assert.assertEquals("a2.pdf", json2.get(JSON_FIELD_FILENAME));
         Assert.assertEquals(3L, json2.get(JSON_FIELD_FILESIZE));
         Assert.assertEquals("genetics:Users.hmccoy", json2.get(JSON_FIELD_AUTHOR));
@@ -212,7 +212,7 @@ public class AttachmentAdapterFactoryTest
     {
         when(this.attachment1.getAuthorReference()).thenReturn(null);
 
-        JSONObject json = this.mocker.getComponentUnderTest().fromXWikiAttachment(this.attachment1).toJSON();
+        JSONObject json = this.mocker.getComponentUnderTest().fromXWikiAttachment(this.attachment1).toJSON(true);
 
         Assert.assertEquals("a1.pdf", json.get(JSON_FIELD_FILENAME));
         Assert.assertEquals(4L, json.get(JSON_FIELD_FILESIZE));
@@ -241,6 +241,13 @@ public class AttachmentAdapterFactoryTest
             + "\"date\":\"2016-08-01T14:00:00.000Z\","
             + "\"content\":\"eHl6\""
             + "}");
+        JSONObject jsonWithOnlyLink = new JSONObject("{"
+                + "\"filename\":\"a3.pdf\","
+                + "\"filesize\":3,"
+                + "\"author\":\"genetics:Users.hmccoy\","
+                + "\"date\":\"2016-08-01T14:00:00.000Z\","
+                + "\"link\":\"http://localhost/a3.pdf\""
+                + "}");
 
         Attachment expected1 = this.mocker.getComponentUnderTest().fromXWikiAttachment(this.attachment1);
         Attachment result1 = this.mocker.getComponentUnderTest().fromJSON(json1);
@@ -252,6 +259,8 @@ public class AttachmentAdapterFactoryTest
 
         Attachment expected2 = this.mocker.getComponentUnderTest().fromXWikiAttachment(this.attachment2);
         Assert.assertEquals(expected2, this.mocker.getComponentUnderTest().fromJSON(json2));
+
+        Assert.assertEquals(null, this.mocker.getComponentUnderTest().fromJSON(jsonWithOnlyLink));
     }
 
     @Test


### PR DESCRIPTION
Fixed by defaulting to including only a link to an attachment in Patient.toJSON() (for medical reports, images and "additional documents")