### PR TITLE
[misc] Revert javadoc plugin update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1118,7 +1118,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <!-- Lock down plugin version for build reproducibility -->
-          <version>3.0.1</version>
+          <version>2.10.4</version>
           <configuration>
             <!-- Always exclude the internal package since it's not user-public -->
             <excludePackageNames>*.internal.*</excludePackageNames>


### PR DESCRIPTION
maven-javadoc-plugin version 3.0.1 fails build with "Failure to find org.phenotips:phenotips-taglets:jar:1.8"