### PR TITLE
PT-3076: Upgrade to XWiki 10

### DIFF
--- a/components/patient-data/ui/src/main/resources/PhenoTips/VCF.xml
+++ b/components/patient-data/ui/src/main/resources/PhenoTips/VCF.xml
@@ -66,6 +66,7 @@
     <reference_genome>
       <cache>0</cache>
       <customDisplay/>
+      <defaultValue>GRCh37</defaultValue>
       <disabled>0</disabled>
       <displayType>select</displayType>
       <multiSelect>0</multiSelect>


### PR DESCRIPTION
Fixed regression: The genome reference no longer defaults to the first value defined in the `values` meta property