### PR TITLE
Add disease suggestion service that uses native vocabulary indices [in progress]

### DIFF
--- a/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/internal/BoqaDiagnosisService.java
+++ b/components/diagnosis-suggestion/api/src/main/java/org/phenotips/diagnosis/internal/BoqaDiagnosisService.java
@@ -1,0 +1,249 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+ */
+package org.phenotips.diagnosis.internal;
+
+import org.phenotips.diagnosis.DiagnosisService;
+import org.phenotips.vocabulary.VocabularyManager;
+import org.phenotips.vocabulary.VocabularyTerm;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.environment.Environment;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+import ontologizer.go.Term;
+import ontologizer.types.ByteString;
+import sonumina.boqa.calculation.BOQA;
+import sonumina.boqa.calculation.Observations;
+
+/**
+ * An implementation of {@link DiagnosisService} using BOQA, see
+ * <a href="http://bioinformatics.oxfordjournals.org/content/28/19/2502.abstract">this article</a>.
+ *
+ * @since 1.1M1
+ * @version $Id$
+ */
+@Singleton
+@Named("boqa")
+@Component
+public class BoqaDiagnosisService implements DiagnosisService, Initializable
+{
+    @Inject
+    private Logger logger;
+
+    private BOQA boqa;
+
+    private Map<Integer, ByteString> omimMap;
+
+    @Inject
+    private VocabularyManager vocabulary;
+
+    @Inject
+    private Environment env;
+
+    @Inject
+    private Utils utils;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        // Initialize boqa
+        this.boqa = new BOQA();
+        this.boqa.setConsiderFrequenciesOnly(false);
+        this.boqa.setPrecalculateScoreDistribution(false);
+        this.boqa.setCacheScoreDistribution(false);
+        this.boqa.setPrecalculateItemMaxs(false);
+        this.boqa.setPrecalculateMaxICs(false);
+        this.boqa.setMaxFrequencyTerms(2);
+        this.boqa.setPrecalculateJaccard(false);
+
+        String annotationPath = null;
+        String vocabularyPath = null;
+        try {
+            annotationPath =
+                stream2file(BOQA.class.getClassLoader().getResourceAsStream("new_phenotype.gz"), "annotation")
+                    .getPath();
+            vocabularyPath =
+                stream2file(BOQA.class.getClassLoader().getResourceAsStream("hp.obo.gz"), "ontology").getPath();
+        } catch (IOException e) {
+            throw new InitializationException(e.getMessage());
+        }
+
+        // Load datafiles
+        try {
+            this.utils.loadDataFiles(vocabularyPath, annotationPath);
+        } catch (InterruptedException e) {
+            throw new InitializationException(e.getMessage());
+        } catch (IOException e) {
+            throw new InitializationException(e.getMessage());
+        }
+
+        this.boqa.setup(this.utils.getGraph(), this.utils.getDataAssociation());
+
+        // Set up our index -> OMIM mapping by flipping the OMIM -> Index mapping in boqa
+        Set<Map.Entry<ByteString, Integer>> omimtonum = this.boqa.item2Index.entrySet();
+        this.omimMap = new HashMap<>(omimtonum.size());
+
+        for (Map.Entry<ByteString, Integer> item : omimtonum) {
+            this.omimMap.put(item.getValue(), item.getKey());
+        }
+    }
+
+    @Override
+    public List<VocabularyTerm> getDiagnosis(List<String> phenotypes, List<String> nonstandardPhenotypes, int limit)
+    {
+        // TODO: use the `nonstandardPhenotypes` argument
+
+        Observations o = new Observations();
+        o.observations = new boolean[this.boqa.getOntology().getNumberOfTerms()];
+        boolean searchIsEmpty = true;
+
+        // Add all hpo terms with ancestors to array of booleans
+        for (String hpo : phenotypes) {
+            Term t = this.boqa.getOntology().getTerm(hpo);
+            searchIsEmpty = !addTermAndAncestors(t, o) && searchIsEmpty;
+        }
+
+        if (searchIsEmpty) {
+            return Collections.emptyList();
+        }
+
+        // Get marginals
+        final BOQA.Result res = this.boqa.assignMarginals(o, false, 1);
+
+        // All of this is sorting diseases by marginals
+        Integer[] order = new Integer[res.size()];
+        for (int i = 0; i < order.length; i++) {
+            order[i] = i;
+        }
+
+        Arrays.sort(order, new Comparator<Integer>()
+        {
+            @Override
+            public int compare(Integer o1, Integer o2)
+            {
+                if (res.getMarginal(o1) < res.getMarginal(o2)) {
+                    return 1;
+                }
+                if (res.getMarginal(o1) > res.getMarginal(o2)) {
+                    return -1;
+                }
+                return 0;
+            }
+        });
+
+        // Get top limit results
+        List<VocabularyTerm> results = new ArrayList<>();
+        for (int id : order) {
+            if (results.size() >= limit) {
+                break;
+            }
+
+            String termId = String.valueOf(this.omimMap.get(id));
+            String vocabularyId = StringUtils.substringBefore(termId, ":");
+
+            // ignore non-OMIM diseases (BOQA has ORPHANET and DECIPHER as well)
+            if (!"OMIM".equals(vocabularyId)) {
+                continue;
+            }
+
+            // Strip 'O' in "OMIM"
+            termId = termId.substring(1);
+
+            VocabularyTerm term = this.vocabulary.resolveTerm(termId);
+
+            if (term == null) {
+                this.logger.warn(String.format(
+                    "Unable to resolve OMIM term '%s' due to outdated OMIM vocabulary.", termId));
+                continue;
+            }
+
+            // Do not suggest diseases that start with *, +, and ^
+            Pattern pattern = Pattern.compile("[*+^]");
+            if (pattern.matcher(term.getName().substring(0, 1)).matches()) {
+                continue;
+            }
+
+            results.add(term);
+
+        }
+
+        this.logger.debug(String.valueOf(results));
+
+        return results;
+    }
+
+    private boolean addTermAndAncestors(Term t, Observations o)
+    {
+        try {
+            int id = this.boqa.getTermIndex(t);
+            o.observations[id] = true;
+            this.boqa.activateAncestors(id, o.observations);
+        } catch (Exception e) {
+            this.logger.warn("Unable to find the boqa index of [{}].", t);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Convert a stream into a file.
+     *
+     * @param in an inputstream
+     * @return a File
+     * @throws IOException when we can't open file
+     */
+    private File stream2file(InputStream in, String nameRoot) throws IOException
+    {
+        File tempDir = this.env.getTemporaryDirectory();
+        final File tempFile;
+        if (tempDir != null) {
+            tempFile = new File(tempDir, String.format("phenotips_boqa_%s.tmp", nameRoot));
+        } else {
+            tempFile = File.createTempFile("phenotips_boqa", ".tmp");
+        }
+        tempFile.deleteOnExit();
+
+        FileOutputStream out = new FileOutputStream(tempFile);
+        IOUtils.copy(in, out);
+
+        return tempFile;
+    }
+}

--- a/components/diagnosis-suggestion/api/src/main/resources/ApplicationResources.properties
+++ b/components/diagnosis-suggestion/api/src/main/resources/ApplicationResources.properties
@@ -1,0 +1,1 @@
+phenotips.diagnosisSuggestions.noMatches=No matches found

--- a/components/diagnosis-suggestion/api/src/main/resources/META-INF/components.txt
+++ b/components/diagnosis-suggestion/api/src/main/resources/META-INF/components.txt
@@ -1,4 +1,5 @@
 org.phenotips.diagnosis.script.DiagnosisScriptService
-org.phenotips.diagnosis.internal.DefaultDiagnosisService
+org.phenotips.diagnosis.internal.BoqaDiagnosisService
 org.phenotips.diagnosis.internal.BoqaInitializer
 org.phenotips.diagnosis.internal.BoqaUtils
+org.phenotips.diagnosis.internal.DefaultDiagnosisService

--- a/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
+++ b/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
@@ -43,7 +43,7 @@
   #if ("$!request.q" != '')##
     #set ($limit = $mathtool.toInteger("$!{request.limit}"))
     #if (!$limit || $limit &lt; 0)
-      #set ($limit = 20)
+      #set ($limit = 10)
     #end
     #set ($symptoms = [])
     #set ($freeSymptoms = [])

--- a/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
+++ b/components/diagnosis-suggestion/ui/src/main/resources/PhenoTips/DiseasePredictService.xml
@@ -40,55 +40,77 @@
   <content>{{velocity filter="indent"}}
 #if ($xcontext.action == 'get')
   $response.setHeader("X-ReqNo", "$!request.reqNo")##
-  #if ("$!request.q" != '')##
+  #if ("$!request.symptom" != '')
+    #set ($_service = $services.diagnosis)
     #set ($limit = $mathtool.toInteger("$!{request.limit}"))
     #if (!$limit || $limit &lt; 0)
       #set ($limit = 10)
     #end
-    #set ($symptoms = [])
-    #set ($freeSymptoms = [])
-    #foreach ($piece in $!request.getParameterValues('symptom'))
-      #set($discard = $symptoms.add($piece))
+    #set ($symptoms = $collectionstool.set)
+    #foreach($i in $request.getParameterValues('symptom'))
+      #set ($discard = $symptoms.add($i))
     #end
     #foreach ($piece in $!request.getParameterValues('free_symptom'))
       #set($discard = $freeSymptoms.add($piece))
     #end
-#if ("$!{request.format}" == 'html')
-#set ($results = $services.diagnosis.get($symptoms, $freeSymptoms, $limit))
-#if ($results.size() &gt; 0)
-{{html clean="false" wiki="false"}}##
-&lt;ul class="vocabulary-term-list"&gt;
-#foreach($term in $results)
-  #set ($name = $term.getName())
-  #set ($id = $term.getId())
-  #if ($term.id.indexOf(':') &gt;= 0)
-    #set ($unprefixedId = $stringtool.substringAfter($term.id, ':'))
-  #else
-    #set ($unprefixedId = $term.id)
-  #end
-  #set ($fullName = $name)
-  #if ($term.short_name &amp;&amp; $term.short_name.size() &gt; 0)
-    #set ($fullName = $fullName.concat('; ').concat($stringtool.join($term.short_name, ', ')))
-  #end
-  &lt;li class="disorder"&gt;
-    &lt;span class="term-id" title="${id}"&gt;&lt;a href="http://www.omim.org/entry/${unprefixedId}" target="_blank" title="${services.localization.render('phenotips.UIXField.diagnosisSuggestions.omimSearch.result.title')}"&gt;${stringtool.defaultString($!term.symbol, ' ')}${unprefixedId}&lt;/a&gt;&lt;/span&gt;
-    &lt;span class="term-name" title="${fullName}"&gt;${name}&lt;/span&gt;
-  &lt;/li&gt;
-#end ## foreach item
-&lt;/ul&gt;
-{{/html}}
-   #set ($hasOutput = true)
-#else
-   #set ($hasOutput = false)
-#end## results.size() &gt; 0
-    #end## html format
+    #set ($results = $_service.get($symptoms, $freeSymptoms, $limit))
+    #set ($hasOutput = false)
+    #if ("$!{request.format}" == 'html')
+      #if ($results.size() &gt; 0)
+        {{html wiki="false" clean="false"}}##
+        &lt;ul class="vocabulary-term-list"&gt;
+          #foreach ($term in $results)
+            #set ($termPrefix = "")
+            #set ($unprefixedId = "$!{term.id}")
+            #set ($termDisplay = "$!{term.id}")
+            #if ($term.id.indexOf(':') &gt;= 0)
+              #set ($termPrefix = $stringtool.substringBefore($term.id, ':').toUpperCase())
+              #set ($unprefixedId = $stringtool.substringAfter($term.id, ':').toUpperCase())
+            #end
+            ## Default to OMIM
+            #if ("$!{termPrefix}" == "" || $termPrefix == "MIM" || $termPrefix == "OMIM")
+              #set ($termUrl = "http://www.omim.org/entry/${escapetool.url($unprefixedId)}")
+              #set ($termDisplay = "${stringtool.defaultString($!{term.symbol}, ' ')}${unprefixedId}")
+            #elseif ($termPrefix == "ORDO" || $termPrefix == "ORPHA" || $termPrefix == "ORPHANET")
+              #set ($termUrl = "http://www.orpha.net/consor/cgi-bin/OC_Exp.php?lng=en&amp;Expert=${escapetool.url($unprefixedId)}")
+            #else
+              #set ($termUrl = "")
+            #end
+            &lt;li class="disorder"&gt;
+              &lt;span class="term-id" title="$escapetool.xml(${term.id})"&gt;
+                #if ("$!{termUrl}" != "")
+                  &lt;a href="${termUrl}" target="_blank" title="${services.localization.render('phenotips.UIXField.diagnosisSuggestions.omimSearch.result.title')}"&gt;${termDisplay}&lt;/a&gt;
+                #else
+                  ${termDisplay}
+                #end
+              &lt;/span&gt;
+              &lt;span class="term-name" title="$escapetool.xml(${term.name})"&gt;${stringtool.defaultString($!{term.short_name}, $!{term.name})}&lt;/span&gt;
+            &lt;/li&gt;
+          #end
+        &lt;/ul&gt;
+        {{/html}}
+        #set ($hasOutput = true)
+      #end## results.size() &gt; 0
+    #elseif ("$!{request.format}" == 'json')
+      #set ($jsonResults = [])
+      #foreach ($term in $results)
+        #set ($discard = $jsonResults.add($term.toJSON()))
+      #end
+      $response.setContentType('application/json')
+      #if ("$!{request.outputSyntax}" == 'plain')
+        {{content syntax="plain/1.0"}}$jsontool.serialize($jsonResults){{/content}}
+      #else
+       {{html wiki="false" clean="false"}}$jsontool.serialize($jsonResults){{/html}}
+      #end
+      #set ($hasOutput = true)
+    #end## format
   #else
     #set ($hasOutput = false)
   #end## non-empty query
 #end## get action
 ##
 #if (!$hasOutput)
-(% class="hint" %)No matches found
+(% class="hint" %)$services.localization.render('phenotips.diagnosisSuggestions.noMatches')
 #end
 {{/velocity}}</content>
 </xwikidoc>


### PR DESCRIPTION
This PR adds a new default diagnosis suggestion implementation that uses the OMIM index and moves the BOQA-based diagnosis suggestion to a separate implementation.

The ScriptService was extended to add the ability to specify a named implementation, e.g.:
`$services.diagnosis.get($symptoms, $freeSymptoms, $limit, "boqa")`

By default it uses the new default implementation.

It addresses the following JIRA issues:
* PT-3934: Add disease suggestion service that uses native vocabulary indices
* PT-3932: Diagnosis suggestions use out-of-date annotations