### PR TITLE
PT-3939: Include whitespace separator in parsing multiple emails in ContactInfo

### DIFF
--- a/components/patient-contacts/src/main/java/org/phenotips/data/ContactInfo.java
+++ b/components/patient-contacts/src/main/java/org/phenotips/data/ContactInfo.java
@@ -225,7 +225,7 @@ public interface ContactInfo
             {
                 List<String> collectedEmails = new ArrayList<String>();
                 for (String email : emails) {
-                    for (String parsedEmail : StringUtils.split(email, ",|;")) {
+                    for (String parsedEmail : StringUtils.split(email, ",; ")) {
                         collectedEmails.add(parsedEmail.trim());
                     }
                 }


### PR DESCRIPTION
Added a blank space to possible separators