### PR TITLE
PT-3959: "Tested Negative/Rejected Candidate" Gene breaks Pedigree Editor

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
@@ -1597,7 +1597,8 @@ define([
                         values.each(function(v) {
                             target._suggestPicker.addItem(v.id, v.gene, '');
                             var legendType = container.getAttribute("legendName");
-                            var geneColor = legendType ? editor.getGeneLegend(legendType).getGeneColor(v.id) : undefined;
+                            var geneColor = (legendType && editor.getGeneLegend(legendType)) ? // Check if getGeneLegend returns null value
+                                            editor.getGeneLegend(legendType).getGeneColor(v.id) : undefined;
                             _this._updateGene(container, v.id, v.id, v.gene, geneColor);
                         })
                     }


### PR DESCRIPTION
Bug fix.

`editor.getGeneLegend(legendType)` will return `null` if there is no associated legend with the gene. Examples would be statuses of "Tested Negative" and "Rejected Candidate". We need to check for a null value before calling `.getGeneColor()`

I tested this small fix on my browser directly using dev tools. Please test on VM (once deployment completes): http://172.20.4.111:8080/