### PR TITLE
PT-3890 Deleted nodes are not fully removed and block drag actions

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/personPlaceholderVisuals.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/personPlaceholderVisuals.js
@@ -39,6 +39,14 @@ define([
             this._genderShape = shape;
             this._genderGraphics = editor.getPaper().set(shape);
         },
+            
+        /**
+         * Overridden to prevent the highlightBox from blocking dragging
+         * action at the location of an invisible placeholder node.
+         */
+        setHighlightBox: function() {
+            this._highlightBox && this._highlightBox.remove();
+        },
 
         /**
          * Overridden to make sure some runaway label does not appear for a placeholder


### PR DESCRIPTION
This bug happens when deleting a lone child. 

The deletion logic for an only child creates an invisible placeholder node (as the algorithms require a child). The blocking element was a highlight box that is created for any type of node. This highlight box is used to indicate which nodes contain a certain gene or phenotype upon hover-over.  Since it should never appear or be used on an invisible placeholder node, it should be permissible to remove it during creation.

Tested briefly using dev tools. Need to test more thoroughly on an instance.

A more time consuming option would be to refactor the onlyChild deletion logic (depreciate the need for `placeholderNode`) and re-test the algorithm behaviour. Another option would be to only generate the highlight box when actually needed, which would involve more modification. 