### PR TITLE
PT-3970: If a gene name contains a colon Solr queries searching for the gene fail

### DIFF
--- a/components/vocabularies/hgnc/api/src/main/java/org/phenotips/vocabulary/internal/solr/GeneNomenclature.java
+++ b/components/vocabularies/hgnc/api/src/main/java/org/phenotips/vocabulary/internal/solr/GeneNomenclature.java
@@ -185,7 +185,8 @@ public class GeneNomenclature extends AbstractCSVSolrVocabulary
         if (StringUtils.isBlank(symbol)) {
             return null;
         }
-        final String id = StringUtils.contains(symbol, SEPARATOR)
+        final String id = (StringUtils.contains(symbol, SEPARATOR)
+                          && !StringUtils.isBlank(StringUtils.substringAfter(symbol, SEPARATOR)))
             ? StringUtils.substringAfter(symbol, SEPARATOR)
             : symbol;
         return requestTerm(ClientUtils.escapeQueryChars(id));


### PR DESCRIPTION
Also need to cherry-pick into stable-1.4.x