### PR TITLE
PT-3971 BOADICEA export breaks if an individual has a date of death specified without a year

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/model/export.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/model/export.js
@@ -498,11 +498,11 @@ define([
          var age = "0";
          var yob = "0";
          var birthDate = new PedigreeDate(pedigree.GG.properties[i]["dob"]);
-         if (birthDate && birthDate.isSet()) {
+         if (birthDate && birthDate.isComplete()) {
              // BOADICEA file format does not support fuzzy dates, so get an estimate if only decade is available
              yob = parseInt(birthDate.getAverageYearEstimate());
              var deathDate = new PedigreeDate(pedigree.GG.properties[i]["dod"]);
-             if (deathDate && deathDate.isSet()) {
+             if (deathDate && deathDate.isComplete()) {
                  var deathDate = new PedigreeDate(pedigree.GG.properties[i]["dod"]);
                  var lastYearAlive = parseInt(deathDate.getAverageYearEstimate());
                  if (deathDate.toJSDate().getDayOfYear() < birthDate.toJSDate().getDayOfYear()) {


### PR DESCRIPTION
Quick fix. `isSet()` returns `true` if any date field was set. `isComplete()` returns `true` if the year is set (a bit misleading).
Since date to timestamp conversion requires at least the year field, using `isComplete()` is the proper check.
Many functions including `toJSDate()` check for the year being present, otherwise it returns null.

The `birthDate` also should use `isComplete()`, otherwise `NaN` will be on the export instead of `0` when there is a node without a birth year.

~There are other uses of `isSet()` that I'll take a look at.~

This fixes the bug and keeps fuzzy date behaviour the same. Uses of `isSet()` elsewhere seem to be valid. Tested locally, but should do more edge case testing.

To test:
- Spin up a VM and follow instructions on original ticket to double check bug is fixed. You might need to hard refresh `Ctrl+Shift+R` on Chrome when you get to the pedigree editor page.
- Adjust dates to include fuzzy and partial dates. Try with other date formats too. If the year is blank, age cannot be calculated so export should contain 0 instead of `NaN` (unless someone decides otherwise).