### PR TITLE
PT-3968: Modifying a group name is not reflected on patient/match table

### DIFF
--- a/components/entity-access-rules/rest/src/main/java/org/phenotips/data/permissions/rest/internal/NameAndEmailExtractor.java
+++ b/components/entity-access-rules/rest/src/main/java/org/phenotips/data/permissions/rest/internal/NameAndEmailExtractor.java
@@ -109,7 +109,7 @@ public class NameAndEmailExtractor
         if (groupObject != null) {
             email = groupObject.getStringValue("contact");
         }
-        String name = document.getDocumentReference().getName();
+        String name = document.getTitle();
         return Pair.of(name, email);
     }
 }


### PR DESCRIPTION
Fetch correct group name in OwnerRepresentation