### PR TITLE
PT-3979 JS injection via group names

### DIFF
--- a/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
+++ b/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
@@ -128,7 +128,7 @@ widgets.UserPicker = Class.create(widgets.Suggest, {
       avatarWrapper.insert(new Element('span', {alt: data.info, 'class': data.icon}));
     }
     container.insert(avatarWrapper);
-    var userName = source.highlight ? this.emphasizeMatches(this.sInput, data.info) : data.info;
+    var userName = (source.highlight ? this.emphasizeMatches(this.sInput, data.info) : data.info).escapeHTML();
     container.insert(new Element('div', {'class': 'user-name'}).update(userName));
     var referenceWrapper = new Element('div');
     var userAlias = source.highlight ? this.emphasizeMatches(this.sInput, data.id.replace(/.*\//g, '')) : data.id;

--- a/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
+++ b/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
@@ -131,7 +131,7 @@ widgets.UserPicker = Class.create(widgets.Suggest, {
     var userName = source.highlight ? this.emphasizeMatches(this.sInput.escapeHTML(), data.info.escapeHTML()) : data.info.escapeHTML();
     container.insert(new Element('div', {'class': 'user-name'}).update(userName));
     var referenceWrapper = new Element('div');
-    var userAlias = source.highlight ? this.emphasizeMatches(this.sInput, data.id.replace(/.*\//g, '')) : data.id;
+    var userAlias = source.highlight ? this.emphasizeMatches(this.sInput, data.id.replace(/.*\//g, '')) : data.id.escapeHTML();
     referenceWrapper.insert(new Element('span', {'class': 'user-alias'}).update(userAlias));
     var userReference = XWiki.Model.resolve(data.value, XWiki.EntityType.DOCUMENT);
     var wiki = userReference.extractReferenceValue(XWiki.EntityType.WIKI) || XWiki.currentWiki;

--- a/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
+++ b/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
@@ -120,6 +120,8 @@ widgets.UserPicker = Class.create(widgets.Suggest, {
 
   // @Override
   createItemDisplay: function(data, source) {
+    data.info = data.info.escapeHTML();
+
     var container = new Element('div', {'class': 'user'});
     var avatarWrapper = new Element('div', {'class': 'user-avatar-wrapper'});
     if (data.icon.indexOf('/') >= 0) {
@@ -128,7 +130,7 @@ widgets.UserPicker = Class.create(widgets.Suggest, {
       avatarWrapper.insert(new Element('span', {alt: data.info, 'class': data.icon}));
     }
     container.insert(avatarWrapper);
-    var userName = (source.highlight ? this.emphasizeMatches(this.sInput, data.info) : data.info).escapeHTML();
+    var userName = source.highlight ? this.emphasizeMatches(this.sInput.escapeHTML(), data.info) : data.info;
     container.insert(new Element('div', {'class': 'user-name'}).update(userName));
     var referenceWrapper = new Element('div');
     var userAlias = source.highlight ? this.emphasizeMatches(this.sInput, data.id.replace(/.*\//g, '')) : data.id;

--- a/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
+++ b/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
@@ -120,17 +120,15 @@ widgets.UserPicker = Class.create(widgets.Suggest, {
 
   // @Override
   createItemDisplay: function(data, source) {
-    data.info = data.info.escapeHTML();
-
     var container = new Element('div', {'class': 'user'});
     var avatarWrapper = new Element('div', {'class': 'user-avatar-wrapper'});
     if (data.icon.indexOf('/') >= 0) {
-      avatarWrapper.insert(new Element('img', {src: data.icon, alt: data.info, 'class': 'icon'}));
+      avatarWrapper.insert(new Element('img', {src: data.icon, alt: data.info.escapeHTML(), 'class': 'icon'}));
     } else {
-      avatarWrapper.insert(new Element('span', {alt: data.info, 'class': data.icon}));
+      avatarWrapper.insert(new Element('span', {alt: data.info.escapeHTML(), 'class': data.icon}));
     }
     container.insert(avatarWrapper);
-    var userName = source.highlight ? this.emphasizeMatches(this.sInput.escapeHTML(), data.info) : data.info;
+    var userName = source.highlight ? this.emphasizeMatches(this.sInput.escapeHTML(), data.info.escapeHTML()) : data.info.escapeHTML();
     container.insert(new Element('div', {'class': 'user-name'}).update(userName));
     var referenceWrapper = new Element('div');
     var userAlias = source.highlight ? this.emphasizeMatches(this.sInput, data.id.replace(/.*\//g, '')) : data.id;

--- a/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
+++ b/components/base-war/src/main/webapp/resources/uicomponents/widgets/userpicker/userPicker.js
@@ -131,7 +131,7 @@ widgets.UserPicker = Class.create(widgets.Suggest, {
     var userName = source.highlight ? this.emphasizeMatches(this.sInput.escapeHTML(), data.info.escapeHTML()) : data.info.escapeHTML();
     container.insert(new Element('div', {'class': 'user-name'}).update(userName));
     var referenceWrapper = new Element('div');
-    var userAlias = source.highlight ? this.emphasizeMatches(this.sInput, data.id.replace(/.*\//g, '')) : data.id.escapeHTML();
+    var userAlias = source.highlight ? this.emphasizeMatches(this.sInput.escapeHTML(), data.id.replace(/.*\//g, '').escapeHTML()) : data.id.escapeHTML();
     referenceWrapper.insert(new Element('span', {'class': 'user-alias'}).update(userAlias));
     var userReference = XWiki.Model.resolve(data.value, XWiki.EntityType.DOCUMENT);
     var wiki = userReference.extractReferenceValue(XWiki.EntityType.WIKI) || XWiki.currentWiki;

--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
@@ -537,7 +537,7 @@
       } else if (owner.id == currentUserName) {
         this._ownerInfo.update(this._OWNER_INFO_TEMPLATE.replace("{0}", "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.selfOwner'))"));
       } else {
-        this._ownerInfo.update(this._OWNER_INFO_TEMPLATE.replace("{0}", iconEl.outerHTML + ' ' + owner.name));
+        this._ownerInfo.update(this._OWNER_INFO_TEMPLATE.replace("{0}", iconEl.outerHTML + ' ' + owner.name.escapeHTML()));
       }
       if (this._newOwnerSelector) {
         this._ownerInfo.insert(" $escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyOwnershipOptions'))");
@@ -1009,7 +1009,7 @@
         var ownerNameEl = new Element('a', {'class' : 'owner'});
         var iconEl = new Element('span', {'class' : (data.owner.type) ? "fa fa-" + data.owner.type : "fa fa-user"}).update(' ');
         ownerNameEl.update(iconEl);
-        ownerNameEl.insert(data.owner.name);
+        ownerNameEl.insert(data.owner.name.escapeHTML());
         ownerNameEl.href = data.owner.url || '';
       }
       ownerNameContainer.update(ownerNameEl);

--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
@@ -867,7 +867,7 @@
       var row = template.cloneNode(true);
       var typeIcon = '&lt;span class="fa fa-'+ item.type +'"&gt; &lt;/span&gt;'
       row.down('.username a').insert({"before" : typeIcon});
-      row.down('.username a').update(item.name);
+      row.down('.username a').update(item.name.escapeHTML());
       row.down('.username a').href = item.url;
       row.down('.' + item.level).update(checkIcon);
       if (item.level == "edit") { row.down('.view').update(checkIcon); }
@@ -1078,7 +1078,7 @@
       var row = new Element('tr', {'class' : (highlight === true ? 'new' : '')});
       row.insert(new Element('td').insert(new Element('span', {'class' : 'fa fa-' + c.type}).update(' ')));
       row.insert(new Element('td')
-              .insert(c.name ? c.name : XWiki.Model.resolve(c.id, XWiki.EntityType.DOCUMENT).name)
+              .insert((c.name ? c.name : XWiki.Model.resolve(c.id, XWiki.EntityType.DOCUMENT).name).escapeHTML())
               .insert(new Element('input', {'type': 'hidden', 'name' : 'collaborator', 'value' : c.id}))
       );
       var rights = this._generateCollaborationOptions('accessLevel', c.level)
@@ -1479,7 +1479,7 @@ $xwiki.ssx.use($serviceDocName)
     #if ($firstCollaborator.isUser())
       #set ($collaboratorName = $xwiki.getUserName("$firstCollaboratorReference", false))
     #else
-      #set ($collaboratorName = $xwiki.getDocument($firstCollaboratorReference).plainTitle)
+      #set ($collaboratorName = $xwiki.getDocument($firstCollaboratorReference).getDisplayTitle())
     #end
     #set ($collaboratorString = $services.localization.render("phenotips.accessRightsManagement.collaboratorsSummary.oneCollaborator", ["(% class='access-rights-info' %){{html wiki='true' clean='false'}}{{icon name='group'/}}&lt;span class='collaborators'&gt;", $collaboratorName, "&lt;/span&gt;{{/html}}(%%)"]))
     #set ($collaboratorTooltipStr = $collaboratorName)
@@ -1493,7 +1493,7 @@ $xwiki.ssx.use($serviceDocName)
       #if ($collaborator.isUser())
         #set ($collaboratorTooltipStr = $collaboratorTooltipStr + $xwiki.getUserName("$collaborator.user", false) + ", ")
       #else
-        #set ($collaboratorTooltipStr = $collaboratorTooltipStr + $xwiki.getDocument($collaborator.user).plainTitle + ", ")
+        #set ($collaboratorTooltipStr = $collaboratorTooltipStr + $xwiki.getDocument($collaborator.user).getDisplayTitle() + ", ")
       #end
     #end
     #set ($collabStrLen = $collaboratorTooltipStr.length() - 2)
@@ -1501,7 +1501,7 @@ $xwiki.ssx.use($serviceDocName)
     #if ($topCollaborator.isUser())
       #set ($topCollaboratorName = $xwiki.getUserName("$topCollaborator.user", false))
     #else
-      #set ($topCollaboratorName = $xwiki.getDocument($topCollaborator.user).plainTitle)
+      #set ($topCollaboratorName = $xwiki.getDocument($topCollaborator.user).getDisplayTitle())
     #end
     #set ($collaboratorsCount = $collaboratorsCount - 1)
     #if ($collaboratorsCount == 1)
@@ -1520,7 +1520,7 @@ $xwiki.ssx.use($serviceDocName)
     #if ($owner.isUser())
       #set ($ownerName = $xwiki.getUserName("$ownerReference", false))
     #else
-      #set ($ownerName = $xwiki.getDocument($ownerReference).plainTitle)
+      #set ($ownerName = $xwiki.getDocument($ownerReference).getDisplayTitle())
     #end
   #end
   #set ($canTransfer = $recordAccess.hasAccessLevel('owner'))

--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
@@ -1055,14 +1055,14 @@
           collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.noCollaborators', ['__beginHtml__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__endHtml__", endHtml);
         } else {
           var collaborator = data.collaborators.collaborators[0];
-          collaborator.name = collaborator.name || XWiki.Model.resolve(collaborator.id, XWiki.EntityType.DOCUMENT).name;
+          var safeCollaboratorName = (collaborator.name || XWiki.Model.resolve(collaborator.id, XWiki.EntityType.DOCUMENT).name).escapeHTML();
           if (collaboratorsCount == 1) {
-            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", collaborator.name).replace("__endHtml__", endHtml);
+            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", safeCollaboratorName).replace("__endHtml__", endHtml);
           } else if (collaboratorsCount == 2) {
-            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneOtherCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", collaborator.name).replace("__endHtml__", endHtml);
+            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneOtherCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", safeCollaboratorName).replace("__endHtml__", endHtml);
           } else {
             var count = collaboratorsCount - 1;
-            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.xOtherCollaborators', ['__beginHtml__', '__collaborator.name__', '__count__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", collaborator.name).replace("__count__", count).replace("__endHtml__", endHtml);
+            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.xOtherCollaborators', ['__beginHtml__', '__collaborator.name__', '__count__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", safeCollaboratorName).replace("__count__", count).replace("__endHtml__", endHtml);
           }
         }
         collaboratorsEl.innerHTML = collaboratorText;
@@ -1479,7 +1479,7 @@ $xwiki.ssx.use($serviceDocName)
     #if ($firstCollaborator.isUser())
       #set ($collaboratorName = $xwiki.getUserName("$firstCollaboratorReference", false))
     #else
-      #set ($collaboratorName = $xwiki.getDocument($firstCollaboratorReference).getDisplayTitle())
+      #set ($collaboratorName = $escapetool.html($xwiki.getDocument($firstCollaboratorReference).plainTitle))
     #end
     #set ($collaboratorString = $services.localization.render("phenotips.accessRightsManagement.collaboratorsSummary.oneCollaborator", ["(% class='access-rights-info' %){{html wiki='true' clean='false'}}{{icon name='group'/}}&lt;span class='collaborators'&gt;", $collaboratorName, "&lt;/span&gt;{{/html}}(%%)"]))
     #set ($collaboratorTooltipStr = $collaboratorName)
@@ -1493,7 +1493,7 @@ $xwiki.ssx.use($serviceDocName)
       #if ($collaborator.isUser())
         #set ($collaboratorTooltipStr = $collaboratorTooltipStr + $xwiki.getUserName("$collaborator.user", false) + ", ")
       #else
-        #set ($collaboratorTooltipStr = $collaboratorTooltipStr + $xwiki.getDocument($collaborator.user).getDisplayTitle() + ", ")
+        #set ($collaboratorTooltipStr = $collaboratorTooltipStr + $escapetool.html($xwiki.getDocument($collaborator.user).plainTitle) + ", ")
       #end
     #end
     #set ($collabStrLen = $collaboratorTooltipStr.length() - 2)
@@ -1501,7 +1501,7 @@ $xwiki.ssx.use($serviceDocName)
     #if ($topCollaborator.isUser())
       #set ($topCollaboratorName = $xwiki.getUserName("$topCollaborator.user", false))
     #else
-      #set ($topCollaboratorName = $xwiki.getDocument($topCollaborator.user).getDisplayTitle())
+      #set ($topCollaboratorName = $escapetool.html($xwiki.getDocument($topCollaborator.user).plainTitle))
     #end
     #set ($collaboratorsCount = $collaboratorsCount - 1)
     #if ($collaboratorsCount == 1)
@@ -1520,7 +1520,7 @@ $xwiki.ssx.use($serviceDocName)
     #if ($owner.isUser())
       #set ($ownerName = $xwiki.getUserName("$ownerReference", false))
     #else
-      #set ($ownerName = $xwiki.getDocument($ownerReference).getDisplayTitle())
+      #set ($ownerName = $escapetool.html($xwiki.getDocument($ownerReference).plainTitle))
     #end
   #end
   #set ($canTransfer = $recordAccess.hasAccessLevel('owner'))

--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
@@ -1055,14 +1055,14 @@
           collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.noCollaborators', ['__beginHtml__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__endHtml__", endHtml);
         } else {
           var collaborator = data.collaborators.collaborators[0];
-          var safeCollaboratorName = (collaborator.name || XWiki.Model.resolve(collaborator.id, XWiki.EntityType.DOCUMENT).name).escapeHTML();
+          collaborator.name = (collaborator.name || XWiki.Model.resolve(collaborator.id, XWiki.EntityType.DOCUMENT).name).escapeHTML();
           if (collaboratorsCount == 1) {
-            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", safeCollaboratorName).replace("__endHtml__", endHtml);
+            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", collaborator.name).replace("__endHtml__", endHtml);
           } else if (collaboratorsCount == 2) {
-            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneOtherCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", safeCollaboratorName).replace("__endHtml__", endHtml);
+            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.oneOtherCollaborator', ['__beginHtml__', '__collaborator.name__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", collaborator.name).replace("__endHtml__", endHtml);
           } else {
             var count = collaboratorsCount - 1;
-            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.xOtherCollaborators', ['__beginHtml__', '__collaborator.name__', '__count__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", safeCollaboratorName).replace("__count__", count).replace("__endHtml__", endHtml);
+            collaboratorText = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.collaboratorsSummary.xOtherCollaborators', ['__beginHtml__', '__collaborator.name__', '__count__', '__endHtml__']))".replace("__beginHtml__", beginHtml).replace("__collaborator.name__", collaborator.name).replace("__count__", count).replace("__endHtml__", endHtml);
           }
         }
         collaboratorsEl.innerHTML = collaboratorText;

--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
@@ -748,7 +748,7 @@
             if (response.statusText == '' /* No response */ || response.status == 12031 /* In IE */) {
               failureReason = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyNoServerResponse'))";
             }
-            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyUpdateFailure')) " + failureReason));
+            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyUpdateFailure')) " + failureReason.escapeHTML()));
           },
           on0 : function(response) {
             response.request.options.onFailure(response);
@@ -791,7 +791,7 @@
             if (response.statusText == '' /* No response */ || response.status == 12031 /* In IE */) {
               failureReason = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyNoServerResponse'))";
             }
-            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyUpdateFailure')) " + failureReason));
+            _this._messages.update(new Element('div', {'class' : 'errormessage'}).update("$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyUpdateFailure')) " + failureReason.escapeHTML()));
           },
           on1223 : function(response) {
             response.request.options.onSuccess(response);
@@ -937,7 +937,7 @@
               if (response.statusText == ''  || response.status == 12031) {
                 failureReason = "$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyNoServerResponse'))";
               }
-              _this._messages.insert(new Element('div', {'class' : 'errormessage'}).update("$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyUpdateFailure')) " + failureReason));
+              _this._messages.insert(new Element('div', {'class' : 'errormessage'}).update("$escapetool.javascript($services.localization.render('phenotips.accessRightsManagement.modifyUpdateFailure')) " + failureReason.escapeHTML()));
             }
           },
           onComplete : function(response) {

--- a/components/users/ui/src/main/resources/XWiki/XWikiGroupSheet.xml
+++ b/components/users/ui/src/main/resources/XWiki/XWikiGroupSheet.xml
@@ -1,0 +1,368 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/
+-->
+
+<xwikidoc version="1.3" reference="XWiki.XWikiGroupSheet" locale="">
+  <web>XWiki</web>
+  <name>XWikiGroupSheet</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>XWiki.XWikiGroups</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.0</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+{{html clean="false"}}
+#set ($discard = $xwiki.ssx.use('XWiki.XWikiGroupSheet'))
+## Keep testing the inline action for backward compatibility with existing groups.
+#if ($xcontext.action == 'edit' || $xcontext.action == 'inline')
+  #if ($request.xpage == 'plain')
+    ## AJAX request.
+    #set ($wrapperTag = 'form')
+    &lt;form class="xform" action="$doc.getURL('preview')"&gt;
+      &lt;input type="hidden" name="form_token" value="$!services.csrf.token" /&gt;
+  #else
+    #set ($discard = $xwiki.jsx.use('XWiki.XWikiGroupSheet'))
+    ## The form is generated in the edit template.
+    #set ($wrapperTag = 'div')
+    &lt;div class="xform"&gt;
+  #end
+    &lt;dl&gt;
+      &lt;dt&gt;&lt;label for="userInput"&gt;$services.localization.render('xe.admin.groups.addUser')&lt;/label&gt;&lt;/dt&gt;
+      &lt;dd&gt;
+        #set ($parameters = {'id': 'userInput', 'name': 'name'})
+        #userPicker(true $parameters)
+      &lt;/dd&gt;
+      &lt;dt&gt;&lt;label for="groupInput"&gt;$services.localization.render('xe.admin.groups.addGroup')&lt;/label&gt;&lt;/dt&gt;
+      &lt;dd&gt;
+        #set ($parameters = {'id': 'groupInput', 'name': 'name'})
+        #groupPicker(true $parameters)
+      &lt;/dd&gt;
+    &lt;/dl&gt;
+    &lt;div class="buttons"&gt;
+      &lt;span class="buttonwrapper"&gt;
+        &lt;button type="submit" id="addMembers" name="xpage" value="adduorg"&gt;
+          $services.localization.render('xe.admin.groups.addUser.submit')
+        &lt;/button&gt;
+      &lt;/span&gt;
+    &lt;/div&gt;
+  &lt;/$wrapperTag&gt;
+#end
+#set ($columnOptions = {
+  'member': {'type': 'text', 'html': true},
+  'type': {'filterable': false, 'sortable': false},
+  'scope': {'filterable': false, 'sortable': false},
+  '_actions': {
+    'actions': ['delete'],
+    'actionCallbacks': {'delete': 'table.deleteRow(i);'},
+    'ajaxActions': {'delete': true},
+    'filterable': false
+   }
+})
+#set ($columns = ['member', 'type'])
+#if (!$xcontext.isMainWiki() &amp;&amp; $services.wiki.user.userScope != 'LOCAL_ONLY')
+  #set ($discard = $columns.add('scope'))
+#end
+## Keep testing the inline action for backward compatibility with existing groups.
+#if ($xcontext.action == 'edit' || $xcontext.action == 'inline')
+  #set ($discard = $columns.add('_actions'))
+#end
+&lt;div class="medium-avatars"&gt;
+  #livetable('groupusers' $columns $columnOptions {
+    'url': $doc.getURL('view', 'xpage=getgroupmembers'),
+    'translationPrefix': 'xe.admin.groups.',
+    'javascriptName': 'editgrouptable',
+    'outputOnlyHtml': true
+  })
+&lt;/div&gt;
+{{/html}}
+{{/velocity}}</content>
+  <object>
+    <name>XWiki.XWikiGroupSheet</name>
+    <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>6e43f145-6962-4b17-a268-f85890a2c00c</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery'], function($) {
+  $(document).on('click', '#addMembers', function(event) {
+    event.preventDefault();
+    var addMembersButton = $(event.target);
+    var form = addMembersButton.closest('form');
+    var parameters = form.serializeArray();
+    // Add the data from the submit button.
+    if (addMembersButton.attr('name')) {
+      parameters.push({
+        name: addMembersButton.attr('name'),
+        value: addMembersButton.val()
+      });
+    }
+    var names = parameters.map(function(parameter) {
+      return parameter.name === 'name' ? parameter.value.trim() : '';
+    }).join('');
+    if (addMembersButton.prop('disabled') || names === '') {
+      // Nothing to add.
+      return;
+    }
+    addMembersButton.prop('disabled', true);
+    $.post(form.attr('action'), parameters).done(function() {
+      // Clear the list of selected users and groups.
+      $('#userInput')[0].selectize.clear(true);
+      $('#groupInput')[0].selectize.clear(true);
+      // Reload the live table.
+      editgrouptable.refresh();
+      // Show notification message.
+      new XWiki.widgets.Notification("$services.localization.render('xe.admin.groups.addSuccess')", 'done', {timeout: 5});
+    }).fail(function(response) {
+      new XWiki.widgets.Notification("$services.localization.render('xe.admin.groups.addFailure')" +
+        response.statusText, 'error', {timeout: 5});
+    }).always(function() {
+      addMembersButton.prop('disabled', false);
+    });
+  });
+});</code>
+    </property>
+    <property>
+      <name>Code</name>
+    </property>
+    <property>
+      <parse>1</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>XWiki.XWikiGroupSheet</name>
+    <number>0</number>
+    <className>XWiki.StyleSheetExtension</className>
+    <guid>9235887d-65c7-4af4-830d-29a42cc869e5</guid>
+    <class>
+      <name>XWiki.StyleSheetExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>6</number>
+        <prettyName>Content Type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>CSS|LESS</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>#template('colorThemeInit.vm')
+
+/* Make sure the selectize dropdown is displayed on top of the Bootstrap modal. */
+body &gt; .selectize-dropdown {
+  z-index: 1051;
+}
+
+/**
+ * Group members live table.
+ */
+
+#groupusers {
+  margin-top: 20px;
+}
+
+#groupusers td[data-title] {
+  vertical-align: middle;
+}
+
+#groupusers td.type,
+#groupusers td.scope {
+  color: $theme.textSecondaryColor;
+}</code>
+    </property>
+    <property>
+      <contentType>CSS</contentType>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>1</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+</xwikidoc>

--- a/components/users/ui/src/main/resources/XWiki/XWikiGroupSheet.xml
+++ b/components/users/ui/src/main/resources/XWiki/XWikiGroupSheet.xml
@@ -72,7 +72,7 @@
   &lt;/$wrapperTag&gt;
 #end
 #set ($columnOptions = {
-  'member': {'type': 'text', 'html': true},
+  'member': {'type': 'text', 'html': false},
   'type': {'filterable': false, 'sortable': false},
   'scope': {'filterable': false, 'sortable': false},
   '_actions': {


### PR DESCRIPTION
- JS did not escape HTML for names. Use PrototypeJS's `.escapeHTML()`
- Use `getDisplayTitle()` which is already escaped, instead of `plainTitle` for group names

These are front end changes and need to be tested more thoroughly.