### PR TITLE
PT-3981: After visiting a "secondary action" link, the text becomes white and therefore unreadable in the default color theme

### DIFF
--- a/components/gene-panels/ui/src/main/resources/PhenoTips/PanelsDisplay.xml
+++ b/components/gene-panels/ui/src/main/resources/PhenoTips/PanelsDisplay.xml
@@ -549,8 +549,10 @@
 }
 
 #panels-livetable input.button,
-#panels-livetable .buttonwrapper button, .buttonwrapper a:visited,
-#panels-livetable .buttonwrapper a:link, .buttonwrapper a:active {
+#panels-livetable .buttonwrapper button,
+#panels-livetable .buttonwrapper a:visited,
+#panels-livetable .buttonwrapper a:link,
+#panels-livetable .buttonwrapper a:active {
   color: $theme.buttonPrimaryTextColor !important;
 }
 


### PR DESCRIPTION
Fixed the CSS selector that was too broad and affected more elements than originally intended.