### PR TITLE
Add the ability to set the livetable backend to a custom url

### DIFF
--- a/components/base-war/src/main/webapp/templates/macros.vm
+++ b/components/base-war/src/main/webapp/templates/macros.vm
@@ -1337,7 +1337,15 @@ ${Msz}Mb##
     #if ("$!resultPage" == '')
       #set ($resultPage = 'XWiki.LiveTableResults')
     #end
-    #set ($dataurl = $xwiki.getURL($resultPage, 'get', "$escapetool.url($parameters)&$!options.extraParams"))
+    #if ($resultPage.startsWith('/'))
+      #set ($webAppPath = "$!xwiki.getWebAppPath()")
+      #if ($webAppPath != '' && !$stringtool.startsWith($webAppPath, '/'))
+         #set ($webAppPath = "/$webAppPath")
+      #end
+      #set ($dataurl = "$!stringtool.stripEnd($!webAppPath,'/')$resultPage?$escapetool.url($parameters)&$!options.extraParams")
+    #else
+      #set ($dataurl = $xwiki.getURL($resultPage, 'get', "$escapetool.url($parameters)&$!options.extraParams"))
+    #end
   #end
   ##
   ## HTML Table


### PR DESCRIPTION
This change is needed in order to allow livetables to point to a rest endpoint instead of the a document.
It only gets triggered if the `resultPage` starts with a `/`.

```
#set ($options = {
  'className'         : $patientClassName,
  'translationPrefix' : 'patient.livetable.',
  'rowCount'          : 50,
  'maxPages'          : 10,
  'selectedColumn'    : $config.getProperty('livetableSortColumn').value,
  'defaultOrder'      : 'asc',
  'topFilters'        : "${topFilters}${columnFiltersContent}",
  'resultPage'        : '/rest/...'
})
```