### PR TITLE
PT-4003: Empty PubMedID are found after PhenoTips 1.3.10 upgrade to 1.4.6

### DIFF
--- a/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R52091PhenoTips670DataMigration.java
+++ b/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R52091PhenoTips670DataMigration.java
@@ -117,6 +117,8 @@ public class R52091PhenoTips670DataMigration extends AbstractHibernateDataMigrat
                 session.save(newValue);
             }
 
+            XWikiContext context = getXWikiContext();
+            context.getWiki().flushCache(context);
             return null;
         }
     }

--- a/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R54693PhenoTips1500DataMigration.java
+++ b/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R54693PhenoTips1500DataMigration.java
@@ -34,6 +34,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.DBStringListProperty;
 import com.xpn.xwiki.objects.StringProperty;
@@ -120,6 +121,9 @@ public class R54693PhenoTips1500DataMigration extends AbstractHibernateDataMigra
                         .warn("Failed to update a global mode of inheritance property: {}", e.getMessage());
                 }
             }
+
+            XWikiContext context = getXWikiContext();
+            context.getWiki().flushCache(context);
             return null;
         }
     }

--- a/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R74690PhenoTips3663DataMigration.java
+++ b/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R74690PhenoTips3663DataMigration.java
@@ -36,6 +36,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.DBStringListProperty;
 import com.xpn.xwiki.objects.StringProperty;
@@ -125,6 +126,9 @@ public class R74690PhenoTips3663DataMigration extends AbstractHibernateDataMigra
                 this.logger.warn("Failed to update a pubmed id property: {}", e.getMessage());
             }
         }
+
+        XWikiContext context = getXWikiContext();
+        context.getWiki().flushCache(context);
         return null;
     }
 

--- a/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R74692PhenoTips3930DataMigration.java
+++ b/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R74692PhenoTips3930DataMigration.java
@@ -36,6 +36,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.DBStringListProperty;
 import com.xpn.xwiki.store.XWikiHibernateBaseStore;
@@ -73,6 +74,8 @@ public class R74692PhenoTips3930DataMigration extends AbstractHibernateDataMigra
     @Named("current")
     private DocumentReferenceResolver<String> resolver;
 
+    private XWikiContext context;
+
     @Override
     public String getDescription()
     {
@@ -97,6 +100,8 @@ public class R74692PhenoTips3930DataMigration extends AbstractHibernateDataMigra
     @Override
     public Object doInHibernate(Session session) throws HibernateException, XWikiException
     {
+        this.context = getXWikiContext();
+
         Query q =
             session.createQuery("select distinct p from BaseObject o, " + DBStringListProperty.class.getName()
                 + " p where o.className = '" + this.serializer.serialize(Patient.CLASS_REFERENCE)
@@ -119,6 +124,7 @@ public class R74692PhenoTips3930DataMigration extends AbstractHibernateDataMigra
                 this.logger.warn("Failed to update a pubmed id property: {}", e.getMessage());
             }
         }
+        this.context.getWiki().flushCache(this.context);
         return null;
     }
 

--- a/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R74692PhenoTips3930DataMigration.java
+++ b/components/patient-data/migrations/src/main/java/org/phenotips/data/internal/R74692PhenoTips3930DataMigration.java
@@ -74,8 +74,6 @@ public class R74692PhenoTips3930DataMigration extends AbstractHibernateDataMigra
     @Named("current")
     private DocumentReferenceResolver<String> resolver;
 
-    private XWikiContext context;
-
     @Override
     public String getDescription()
     {
@@ -100,8 +98,6 @@ public class R74692PhenoTips3930DataMigration extends AbstractHibernateDataMigra
     @Override
     public Object doInHibernate(Session session) throws HibernateException, XWikiException
     {
-        this.context = getXWikiContext();
-
         Query q =
             session.createQuery("select distinct p from BaseObject o, " + DBStringListProperty.class.getName()
                 + " p where o.className = '" + this.serializer.serialize(Patient.CLASS_REFERENCE)
@@ -124,7 +120,9 @@ public class R74692PhenoTips3930DataMigration extends AbstractHibernateDataMigra
                 this.logger.warn("Failed to update a pubmed id property: {}", e.getMessage());
             }
         }
-        this.context.getWiki().flushCache(this.context);
+
+        XWikiContext context = getXWikiContext();
+        context.getWiki().flushCache(context);
         return null;
     }
 

--- a/components/patient-measurements/migrations/src/main/java/org/phenotips/measurements/internal/R45190PhenoTips362DataMigration.java
+++ b/components/patient-measurements/migrations/src/main/java/org/phenotips/measurements/internal/R45190PhenoTips362DataMigration.java
@@ -29,6 +29,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.FloatProperty;
 import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
@@ -59,6 +60,7 @@ public class R45190PhenoTips362DataMigration extends AbstractHibernateDataMigrat
     }
 
     @Override
+    @SuppressWarnings("checkstyle:AnonInnerLength")
     public void hibernateMigrate() throws DataMigrationException, XWikiException
     {
         getStore().executeWrite(getXWikiContext(), new HibernateCallback<Object>()
@@ -78,6 +80,9 @@ public class R45190PhenoTips362DataMigration extends AbstractHibernateDataMigrat
                     session.save(updated);
                     session.delete(property);
                 }
+
+                XWikiContext context = getXWikiContext();
+                context.getWiki().flushCache(context);
                 return null;
             }
         });

--- a/components/patient-measurements/migrations/src/main/java/org/phenotips/measurements/internal/R54691PhenoTips1428DataMigration.java
+++ b/components/patient-measurements/migrations/src/main/java/org/phenotips/measurements/internal/R54691PhenoTips1428DataMigration.java
@@ -29,6 +29,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.Query;
 import org.hibernate.Session;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.FloatProperty;
 import com.xpn.xwiki.objects.IntegerProperty;
@@ -90,6 +91,9 @@ public class R54691PhenoTips1428DataMigration extends AbstractHibernateDataMigra
                 session.delete(oldAgeProperty);
                 session.save(newAgeProperty);
             }
+
+            XWikiContext context = getXWikiContext();
+            context.getWiki().flushCache(context);
             return null;
         }
     }

--- a/components/studies/migrations/src/main/java/org/phenotips/data/permissions/internal/R71492PhenoTips2592DataMigration.java
+++ b/components/studies/migrations/src/main/java/org/phenotips/data/permissions/internal/R71492PhenoTips2592DataMigration.java
@@ -30,6 +30,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.DBStringListProperty;
 import com.xpn.xwiki.objects.StringListProperty;
@@ -92,6 +93,8 @@ public class R71492PhenoTips2592DataMigration extends AbstractHibernateDataMigra
             session.save(newValue);
         }
 
+        XWikiContext context = getXWikiContext();
+        context.getWiki().flushCache(context);
         return null;
     }
 }

--- a/components/studies/migrations/src/main/java/org/phenotips/data/permissions/internal/R71493PhenoTips2504DataMigration.java
+++ b/components/studies/migrations/src/main/java/org/phenotips/data/permissions/internal/R71493PhenoTips2504DataMigration.java
@@ -30,6 +30,7 @@ import org.hibernate.Query;
 import org.hibernate.Session;
 import org.slf4j.Logger;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.DBStringListProperty;
 import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
@@ -54,6 +55,8 @@ public class R71493PhenoTips2504DataMigration extends AbstractHibernateDataMigra
     @Inject
     private Logger logger;
 
+    private XWikiContext context;
+
     @Override
     public String getDescription()
     {
@@ -75,6 +78,7 @@ public class R71493PhenoTips2504DataMigration extends AbstractHibernateDataMigra
     @Override
     public Object doInHibernate(Session session) throws HibernateException, XWikiException
     {
+        this.context = getXWikiContext();
         Query q =
             session.createQuery("select p from " + DBStringListProperty.class.getName() + " as p, BaseObject as o"
                 + " where o.className='PhenoTips.StudyClass' and p.id.id=o.id"
@@ -89,7 +93,7 @@ public class R71493PhenoTips2504DataMigration extends AbstractHibernateDataMigra
             values.remove("org.phenotips.patientSheet.field.rejected_genes");
             session.update(property);
         }
-
+        this.context.getWiki().flushCache(this.context);
         return null;
     }
 }


### PR DESCRIPTION
XWiki cache has to be flushed at the end of migrator to prevent loading documents from the cache rather than from database.