### PR TITLE
PT-4002 (stable): Reindexing HPO fails when an HPO term has more than one single value type field

### DIFF
--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOBOSolrVocabulary.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOBOSolrVocabulary.java
@@ -115,7 +115,7 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
             return 2;
         }
         try {
-            Set<String> singleValuedFileds = getSingleValuedFields();
+            Set<String> singleValuedFields = getSingleValuedFields();
 
             Collection<SolrInputDocument> termBatch = new HashSet<>();
             Iterator<Map.Entry<String, TermData>> dataIterator = data.entrySet().iterator();
@@ -135,8 +135,7 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
                     String name = property.getKey();
                     for (String value : property.getValue()) {
                         // check if property is single value type and has been already added
-                        if (singleValuedFileds.contains(name) && addedFields.contains(name))
-                        {
+                        if (singleValuedFields.contains(name) && addedFields.contains(name)) {
                             break;
                         }
                         doc.addField(name, value);
@@ -203,7 +202,7 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
     }
 
     /**
-     * Returns list of single-valued schema filed names .
+     * Returns list of single-valued schema field names .
      *
      * @return list of names
      */

--- a/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOBOSolrVocabulary.java
+++ b/components/vocabularies/api/src/main/java/org/phenotips/vocabulary/internal/solr/AbstractOBOSolrVocabulary.java
@@ -23,16 +23,22 @@ import org.phenotips.vocabulary.VocabularyTerm;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.response.schema.SchemaResponse.FieldsResponse;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.apache.solr.common.SolrException;
@@ -99,6 +105,7 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
      *         specified URL is invalid
      */
     @Override
+    @SuppressWarnings({ "checkstyle:CyclomaticComplexity" })
     protected int index(String sourceUrl)
     {
         String url = StringUtils.defaultIfBlank(sourceUrl, getDefaultSourceLocation());
@@ -108,6 +115,8 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
             return 2;
         }
         try {
+            Set<String> singleValuedFileds = getSingleValuedFields();
+
             Collection<SolrInputDocument> termBatch = new HashSet<>();
             Iterator<Map.Entry<String, TermData>> dataIterator = data.entrySet().iterator();
             int batchCounter = 0;
@@ -118,12 +127,20 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
                     termBatch = new HashSet<>();
                     batchCounter = 0;
                 }
+                Set<String> addedFields = new HashSet<>();
                 Map.Entry<String, TermData> item = dataIterator.next();
                 SolrInputDocument doc = new SolrInputDocument();
+
                 for (Map.Entry<String, Collection<String>> property : item.getValue().entrySet()) {
                     String name = property.getKey();
                     for (String value : property.getValue()) {
+                        // check if property is single value type and has been already added
+                        if (singleValuedFileds.contains(name) && addedFields.contains(name))
+                        {
+                            break;
+                        }
                         doc.addField(name, value);
+                        addedFields.add(name);
                     }
                 }
                 extendTerm(new SolrVocabularyInputTerm(doc, this));
@@ -183,5 +200,29 @@ public abstract class AbstractOBOSolrVocabulary extends AbstractSolrVocabulary
             this.logger.warn("Failed to query vocabulary version: {}", ex.getMessage());
         }
         return null;
+    }
+
+    /**
+     * Returns list of single-valued schema filed names .
+     *
+     * @return list of names
+     */
+    private Set<String> getSingleValuedFields()
+    {
+        try {
+            SolrClient client = this.externalServicesAccess.getSolrConnection(this);
+            FieldsResponse fieldsExists = new SchemaRequest.Fields().process(client);
+            if (fieldsExists.getFields() != null) {
+                Set<String> fields = fieldsExists.getFields().stream()
+                    .filter(fieldDefinition -> fieldDefinition.get("multiValued") == null
+                        || !(Boolean) fieldDefinition.get("multiValued"))
+                    .map(fieldDefinition -> (String) fieldDefinition.get("name"))
+                    .collect(Collectors.toSet());
+                return fields;
+            }
+        } catch (Exception ex) {
+            this.logger.warn("Exception while parsing vocabulary schema: {}", ex.getMessage());
+        }
+        return Collections.emptySet();
     }
 }

--- a/components/vocabularies/chebi/api/src/test/java/org/phenotips/vocabulary/internal/solr/ChEBIOntologyTest.java
+++ b/components/vocabularies/chebi/api/src/test/java/org/phenotips/vocabulary/internal/solr/ChEBIOntologyTest.java
@@ -45,7 +45,6 @@ import org.mockito.Mockito;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 /**
  * Tests for the ChEBI implementation of the {@link org.phenotips.vocabulary.Vocabulary},
  * {@link org.phenotips.vocabulary.internal.solr.ChEBIOntology}.
@@ -88,7 +87,7 @@ public class ChEBIOntologyTest
         Mockito.verify(this.server, Mockito.atLeast(1)).commit();
         Mockito.verify(this.server, Mockito.atLeast(1)).add(Matchers.anyCollectionOf(SolrInputDocument.class));
         Mockito.verify(this.cache, Mockito.atLeast(1)).removeAll();
-        Mockito.verifyNoMoreInteractions(this.cache, this.server);
+        Mockito.verifyNoMoreInteractions(this.cache);
         Assert.assertTrue(this.ontologyServiceResult == 0);
     }
 

--- a/components/vocabularies/hpo/api/src/test/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntologyTest.java
+++ b/components/vocabularies/hpo/api/src/test/java/org/phenotips/vocabulary/internal/solr/HumanPhenotypeOntologyTest.java
@@ -94,7 +94,7 @@ public class HumanPhenotypeOntologyTest
         Mockito.verify(this.server).commit();
         Mockito.verify(this.server).add(Matchers.anyCollectionOf(SolrInputDocument.class));
         Mockito.verify(this.cache).removeAll();
-        Mockito.verifyNoMoreInteractions(this.cache, this.server);
+        Mockito.verifyNoMoreInteractions(this.cache);
         Assert.assertTrue(this.ontologyServiceResult == 0);
     }
 


### PR DESCRIPTION

Fixed.