### PR TITLE
PT-4006: Tooltips width is too narrow for genes dropdown

### DIFF
--- a/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
+++ b/components/patient-access-rules/ui/src/main/resources/PhenoTips/AccessRightsManagement.xml
@@ -1327,17 +1327,13 @@ document.observe("xwiki:dom:loaded", function() {
 }
 
 #users-access-rights-table .xTooltip {
+  width: 30%;
+  white-space: normal;
   text-align: left;
 }
 
 .table-filters {
   margin-top : 10px;
-}
-
-.xTooltip {
-  width: 30%;
-  white-space: normal;
-  text-align: left;
 }
 
 .fa.fa-user {


### PR DESCRIPTION
Fixed