### PR TITLE
PT-4018: Pedigree node life status not loaded from saved JSON

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/model/phenotipsJSON.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/model/phenotipsJSON.js
@@ -181,9 +181,7 @@ define([
         }
         if (patientJSON.hasOwnProperty("life_status")) {
             var lifeStatus = patientJSON["life_status"];
-            if (lifeStatus == "deceased" || lifeStatus == "alive") {
-                result.lifeStatus = lifeStatus;
-            }
+            result.lifeStatus = lifeStatus;
             if (lifeStatus != "alive") {
                 // if not removed, it will overwrite the life status to 'alive' and thus remove death date
                 delete result.aliveandwell;


### PR DESCRIPTION
The `life_status` field takes values other than "alive" and "deceased" in regular, unlinked family member node json representations. Perhaps it was meant to be a special pedigreeProperty, but as is this drops all other life status values, causing it to return to the default of "alive".