### PR TITLE
PT-4020 In the pedigree editor, cancer labels are sometimes vertically offset from the relevant individual

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/personVisuals.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/personVisuals.js
@@ -822,9 +822,10 @@ define([
          */
         updateCommentsLabel: function() {
             this.getCommentsLabel() && this.getCommentsLabel().remove();
+            var text = typeof this.getNode().getComments() === 'string' ? this.getNode().getComments() : "";
             // note: raphael positions text which starts with a new line in a strange way
             //       also, blank lines are ignored unless replaced with a space
-            var text = this.getNode().getComments().replace(/^\s+|\s+$/g,'').replace(/\n\n/gi,'\n \n');
+            text = text.replace(/^\s+|\s+$/g,'').replace(/\n\n/gi,'\n \n');
             if (text != "") {
                 this._commentsLabel = editor.getPaper().text(this.getX(), this.getY(), text).attr(PedigreeEditorParameters.attributes.commentLabel);
                 this._commentsLabel.node.setAttribute("class", "field-no-user-select");

--- a/components/pedigree/resources/src/main/resources/pedigree/view/personVisuals.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/personVisuals.js
@@ -822,10 +822,10 @@ define([
          */
         updateCommentsLabel: function() {
             this.getCommentsLabel() && this.getCommentsLabel().remove();
-            if (this.getNode().getComments() != "") {
-                // note: raphael positions text which starts with a new line in a strange way
-                //       also, blank lines are ignored unless replaced with a space
-                var text = this.getNode().getComments().replace(/^\s+|\s+$/g,'').replace(/\n\n/gi,'\n \n');
+            // note: raphael positions text which starts with a new line in a strange way
+            //       also, blank lines are ignored unless replaced with a space
+            var text = this.getNode().getComments().replace(/^\s+|\s+$/g,'').replace(/\n\n/gi,'\n \n');
+            if (text != "") {
                 this._commentsLabel = editor.getPaper().text(this.getX(), this.getY(), text).attr(PedigreeEditorParameters.attributes.commentLabel);
                 this._commentsLabel.node.setAttribute("class", "field-no-user-select");
                 this._commentsLabel.alignTop = true;


### PR DESCRIPTION
@allasm helpfully suggested a quick fix for this: making the user-defined `comments` label be the last one displayed (i.e. changing the order of labels displayed). He suggested adding better error checking for the values returned by `getBBox()` as a long-term solution.

After taking a closer look, I decided to fix the `comments` label rendering behaviour. This seems to me like a more targeted fix, since it does not change UX behaviour (i.e. order of the labels) and fixes the bug that's really relevant here (i.e. that the user-defined `comments` label is rendered even when it's effectively empty). Better error-checking for the values returned by `getBBox()` could still be added as an improvement, but shouldn't really be necessary.