### PR TITLE
PT-4019 After any edits, cursor is placed to the very end of the comment box in IE11

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/view/nodeMenu.js
@@ -612,8 +612,9 @@ define([
         _saveCursorPositionIfNecessary: function(field) {
             this.__lastSelectedField  = field.name;
             this.__lastNodeID         = this.targetNode;
-            // for text fields in all browsers, and textarea only in IE9
-            if (field.type == "text" || (document.selection && field.type == "textarea")) {
+            // for text fields in all browsers, and textarea only in IE
+            var isIE = navigator && navigator.appVersion.indexOf('Trident/') > -1;
+            if (field.type == "text" || (isIE && field.type == "textarea")) {
                 this.__lastCursorPosition = GraphicHelpers.getCaretPosition(field);
             }
         },
@@ -621,9 +622,10 @@ define([
         _restoreCursorPositionIfNecessary: function(field) {
             if (this.targetNode == this.__lastNodeID &&
                 field.name      == this.__lastSelectedField) {
-                // for text fields in all browsers, and textarea only in IE9
-                if (field.type == "text" || (document.selection && field.type == "textarea")) {
+                // for text fields in all browsers, and textarea only in IE
+                if (this.__lastCursorPosition !== undefined && (field.type == "text" || field.type == "textarea")) {
                     GraphicHelpers.setCaretPosition(field, this.__lastCursorPosition);
+                    this.__lastCursorPosition = undefined;
                 }
             }
         },


### PR DESCRIPTION
This broke because `document.selection` stopped working in IE11 (it's `undefined`).

My solution is to use a different way to check whether the browser is IE, and then to restore the cursor position if it had been saved (rather than checking the browser type again in the restore).