### PR TITLE
PT-3917: sensitive pedigree details are shown when the pedigree is opened

### DIFF
--- a/components/pedigree/resources/src/main/resources/pedigree/familyData.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/familyData.js
@@ -11,12 +11,11 @@ define([
         Helpers
     ){
     var FamilyData = Class.create( {
-        DEFAULT_SENSITIVE_DATA_MESSAGE: "This pedigree was marked as containing sensitive information. No further details were provided.",
-
         initialize: function() {
             this.familyPage = null;
             this.familyMembers = [];
             this.familyMembersIndex = {};
+            this.hasSensitiveData = false;
             this.warningMessage = "";
         },
 
@@ -35,8 +34,8 @@ define([
                 this.familyMembersIndex[this.familyMembers[i].id] = i;
             }
 
-            // set to null if no sensitive data present, set to DEFAULT_SENSITIVE_DATA_MESSAGE if provided message is blank, otherwise use provided
-            this.warningMessage = familyJSON["contains_sensitive_data"] ? (familyJSON["sensitive_data_message"] || this.DEFAULT_SENSITIVE_DATA_MESSAGE) : null;
+            this.hasSensitiveData = Boolean(familyJSON["contains_sensitive_data"]);
+            this.warningMessage = familyJSON["sensitive_data_message"] || "";
 
             console.log("Family data:  [familyPage: " + this.familyPage +
                     "], [editingFamilyPage: " + Helpers.stringifyObject(this.isFamilyPage()) + "], [Members:" +
@@ -56,7 +55,7 @@ define([
         },
 
         hasWarningMessage: function() {
-            return (this.warningMessage != null);
+            return this.hasSensitiveData;
         },
 
         getLoadedFamilyMembers: function() {
@@ -64,7 +63,7 @@ define([
         },
 
         getWarningMessage: function() {
-            return this.warningMessage;
+            return this.hasSensitiveData ? this.warningMessage : "";
         },
 
         isFamilyMember: function(patientID) {

--- a/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
@@ -411,7 +411,7 @@ define([
                 options,
                 continueMessage, null,
                 cancelMessage, editor.closePedigree,
-                toggleDetailsButtonText, toggleDetails, true);
+                toggleDetailsButtonText, toggleDetails);
         },
 
         _loadFromFamilyInfoJSON: function(responseJSON) {

--- a/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
+++ b/components/pedigree/resources/src/main/resources/pedigree/saveLoadEngine.js
@@ -384,6 +384,36 @@ define([
             });
         },
 
+        _showSensitiveDataWarning: function(showDetails) {
+            var title = "Attention: sensitive information";
+            var message = "This pedigree contains sensitive information.";
+            var warningMessage = editor.getFamilyData().getWarningMessage();
+            var continueMessage = "Continue to pedigree";
+            var cancelMessage = editor.isFamilyPage() ? "Go to family record" : "Go to patient record";
+            var toggleDetailsButtonText = showDetails ? "Hide details" : "Show details";
+            var toggleDetails = this._showSensitiveDataWarning.bind(this, !showDetails);
+            var options = { "screenBackground": "opaque", "button1": { "keepBackgroundScreenWhenPressed": true } };
+
+            // Just append warning message to dialog mody if showing details
+            if (showDetails && warningMessage) {
+                message += "<br /><br />" + warningMessage;
+            }
+
+            // Don't display toggleDetails button if there are no details to display
+            if (!warningMessage) {
+                toggleDetailsButtonText = null;
+                toggleDetails = null;
+            }
+
+            editor.getOkCancelDialogue().showWithOptions(
+                message,
+                title,
+                options,
+                continueMessage, null,
+                cancelMessage, editor.closePedigree,
+                toggleDetailsButtonText, toggleDetails, true);
+        },
+
         _loadFromFamilyInfoJSON: function(responseJSON) {
             if (responseJSON) {
                 console.log("[LOAD] received JSON: " + Helpers.stringifyObject(responseJSON));
@@ -407,11 +437,7 @@ define([
 
                         // display a warning if there is "sensitive information" associated with the family
                         if (editor.getFamilyData().hasWarningMessage()) {
-                            editor.getOkCancelDialogue().showWithOptions(
-                                editor.getFamilyData().getWarningMessage(),
-                                "Attention: This pedigree contains sensitive information",
-                                { "screenBackground": "opaque", "button1": {"keepBackgroundScreenWhenPressed": true} },
-                                "Continue to pedigree", null, "Quit", function() { editor.closePedigree() });
+                            this._showSensitiveDataWarning(false);
                         }
 
                         return;


### PR DESCRIPTION
In the current version, if you open the pedigree, it immediately alerts you to exactly that sensitive information that you might not want to see with the patient present:
<img width="752" alt="image" src="https://user-images.githubusercontent.com/4251264/60066790-2e920500-96d6-11e9-9977-7d48669ca733.png">

In the PR version, it first displays a generic break-glass message, with options to continue, go to the record, or show the details:
![image](https://user-images.githubusercontent.com/4251264/60066718-030f1a80-96d6-11e9-81fe-d66daad6ca71.png)

If you click "Show details", it displays them below:
![image](https://user-images.githubusercontent.com/4251264/60066724-0904fb80-96d6-11e9-9fbf-574ea6dda1be.png)

If you didn't provide any details, it doesn't show the button at all.
![image](https://user-images.githubusercontent.com/4251264/60066733-0dc9af80-96d6-11e9-8087-bdb8d4f96cfb.png)
